### PR TITLE
Correctly process returned message at send audio

### DIFF
--- a/src/main/java/org/telegram/telegrambots/api/methods/SendAudio.java
+++ b/src/main/java/org/telegram/telegrambots/api/methods/SendAudio.java
@@ -17,6 +17,9 @@ import org.telegram.telegrambots.api.objects.ReplyKeyboard;
 public class SendAudio {
     public static final String PATH = "sendaudio";
 
+	public static final String DURATION_FIELD = "duration";
+	private Integer duration; ///< Integer	Duration of the audio in seconds as defined by sender
+
     public static final String CHATID_FIELD = "chat_id";
     private String chatId; ///< Unique identifier for the chat to send the message to (or Username fro channels)
     public static final String AUDIO_FIELD = "audio";
@@ -43,6 +46,14 @@ public class SendAudio {
     public SendAudio() {
         super();
     }
+
+	public void setDuration(Integer duration) {
+        this.duration = duration;
+    }
+
+	public Integer getDuration(){
+		return this.duration;
+	}
 
     public String getChatId() {
         return chatId;

--- a/src/main/java/org/telegram/telegrambots/api/objects/Message.java
+++ b/src/main/java/org/telegram/telegrambots/api/objects/Message.java
@@ -138,6 +138,9 @@ public class Message implements IBotApiObject {
         if (jsonObject.has(VIDEO_FIELD)) {
             this.video = new Video(jsonObject.getJSONObject(VIDEO_FIELD));
         }
+        if(jsonObject.has(AUDIO_FIELD)){
+        	this.audio = new Audio(jsonObject.getJSONObject(AUDIO_FIELD));
+        }
         if (jsonObject.has(CONTACT_FIELD)) {
             this.contact = new Contact(jsonObject.getJSONObject(CONTACT_FIELD));
         }

--- a/src/main/java/org/telegram/telegrambots/api/objects/Message.java
+++ b/src/main/java/org/telegram/telegrambots/api/objects/Message.java
@@ -138,9 +138,6 @@ public class Message implements IBotApiObject {
         if (jsonObject.has(VIDEO_FIELD)) {
             this.video = new Video(jsonObject.getJSONObject(VIDEO_FIELD));
         }
-        if(jsonObject.has(AUDIO_FIELD)){
-        	this.audio = new Audio(jsonObject.getJSONObject(AUDIO_FIELD));
-        }
         if (jsonObject.has(CONTACT_FIELD)) {
             this.contact = new Contact(jsonObject.getJSONObject(CONTACT_FIELD));
         }

--- a/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
+++ b/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
@@ -520,16 +520,16 @@ public abstract class AbsSender {
 
         JSONObject jsonObject = new JSONObject(responseContent);
 
-        //if we got an ok, then we can expect a "reseult" section. and out of this can a new Message object be built
-        if(jsonObject.has("ok") && jsonObject.getBoolean("ok")){
-        	return new Message(jsonObject.getJSONObject("result"));
+        /* if we got not an "ok" with false, we have a response like that
+         * 
+         * {"description":"[Error]: Bad Request: chat not found","error_code":400,"ok":false}
+         */
+        if(!jsonObject.getBoolean("ok")){
+        	throw new TelegramApiException("Error at sendAudio", jsonObject.getString("description"));
         }
         
-        //and if not, there should be a field in our jsonObject that represents a boolean "false" with a key of "ok" 
-        	//{"description":"[Error]: Bad Request: chat not found","error_code":400,"ok":false}
-        // for example. and can throw an exception, cause there was an error...
-        throw new TelegramApiException("Error at sendAudio", jsonObject.getString("description"));
-           
+         // and if not, we can expect a "result" section. and out of this can a new Message object be built
+        return new Message(jsonObject.getJSONObject("result"));           
     }
 
     /**

--- a/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
+++ b/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
@@ -520,7 +520,8 @@ public abstract class AbsSender {
 
         JSONObject jsonObject = new JSONObject(responseContent);
 
-        if(jsonObject.has("result")){
+        //if we got an ok, then we can expect a "reseult" section. and out of this can a new Message object be built
+        if(jsonObject.has("ok") && jsonObject.getBoolean("ok")){
         	return new Message(jsonObject.getJSONObject("result"));
         }
         

--- a/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
+++ b/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
@@ -458,6 +458,7 @@ public abstract class AbsSender {
     public Message sendAudio(SendAudio sendAudio) throws TelegramApiException {
         String responseContent;
 
+        
         try {
             CloseableHttpClient httpClient = HttpClients.createDefault();
             String url = getBaseUrl() + SendAudio.PATH;
@@ -478,6 +479,9 @@ public abstract class AbsSender {
                 }
                 if (sendAudio.getTitle() != null) {
                     builder.addTextBody(SendAudio.TITLE_FIELD, sendAudio.getTitle());
+                }
+                if(sendAudio.getDuration() != null){
+                	builder.addTextBody(SendAudio.DURATION_FIELD, sendAudio.getDuration().toString());
                 }
                 if (sendAudio.getDisableNotification() != null) {
                     builder.addTextBody(SendAudio.DISABLENOTIFICATION_FIELD, sendAudio.getDisableNotification().toString());

--- a/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
+++ b/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
@@ -519,11 +519,16 @@ public abstract class AbsSender {
         }
 
         JSONObject jsonObject = new JSONObject(responseContent);
-        if (!jsonObject.getBoolean("ok")) {
-            throw new TelegramApiException("Error at sendAudio", jsonObject.getString("description"));
-        }
 
-        return new Message(jsonObject);
+        if(jsonObject.has("result")){
+        	return new Message(jsonObject.getJSONObject("result"));
+        }
+        
+        //and if not, there should be a field in our jsonObject that represents a boolean "false" with a key of "ok" 
+        	//{"description":"[Error]: Bad Request: chat not found","error_code":400,"ok":false}
+        // for example. and can throw an exception, cause there was an error...
+        throw new TelegramApiException("Error at sendAudio", jsonObject.getString("description"));
+           
     }
 
     /**


### PR DESCRIPTION
I tried to get the returned message when I send an audio file with sendAudio. 

response after a successful transmission:

```
{
   "result":{
      "date":1458073077,
      "reply_to_message":{
         "date":1458073068,
         "chat":{
            "id":My_id,
            "type":"private",
            "first_name":"My_Name",
            "username":"My_Username"
         },
         "message_id":771,
         "from":{
            "id":My_Id,
            "first_name":"My_Name",
            "username":"My_Username"
         },
         "text":"https://www.youtube.com/watch?v=C0DPdy98e4c"
      },
      "chat":{
         "id":My_Id,
         "type":"private",
         "first_name":"My_Name",
         "username":"My_Username"
      },
      "message_id":772,
      "from":{
         "id":MyBot_Id,
         "first_name":"MyBot",
         "username":"MyBot"
      },
      "audio":{
         "duration":0,
         "file_id":"[returned_file_id]",
         "title":"TEST VIDEO",
         "file_size":91438
      }
   },
   "ok":true
}
```

Out of my research every successfull transmission has a "result" object.

Please correct me, if I understand anything not in a correct manner