### PR TITLE
fix Class cast exception

### DIFF
--- a/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
+++ b/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
@@ -93,12 +93,12 @@ public abstract class AbsSender {
         return (Message) sendApiMethod(forwardMessage);
     }
 
-    public File sendLocation(SendLocation sendLocation) throws TelegramApiException {
+    public Message sendLocation(SendLocation sendLocation) throws TelegramApiException {
         if (sendLocation == null) {
             throw new TelegramApiException("Parameter sendLocation can not be null");
         }
 
-        return (File) sendApiMethod(sendLocation);
+        return (Message) sendApiMethod(sendLocation);
     }
 
     public UserProfilePhotos getUserProfilePhotos(GetUserProfilePhotos getUserProfilePhotos) throws TelegramApiException {


### PR DESCRIPTION
Bug fix:

 java.lang.ClassCastException: org.telegram.telegrambots.api.objects.Message cannot be cast to org.telegram.telegrambots.api.objects.File
	at org.telegram.telegrambots.bots.AbsSender.sendLocation(AbsSender.java:101)
