### PR TITLE
Closeable Bot Sessions

### DIFF
--- a/src/main/java/org/telegram/telegrambots/TelegramBotsApi.java
+++ b/src/main/java/org/telegram/telegrambots/TelegramBotsApi.java
@@ -15,7 +15,7 @@ import org.json.JSONObject;
 import org.telegram.telegrambots.api.methods.updates.SetWebhook;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
 import org.telegram.telegrambots.bots.TelegramWebhookBot;
-import org.telegram.telegrambots.updatesreceivers.UpdatesThread;
+import org.telegram.telegrambots.updatesreceivers.BotSession;
 import org.telegram.telegrambots.updatesreceivers.Webhook;
 
 import java.io.File;
@@ -122,12 +122,12 @@ public class TelegramBotsApi {
     }
 
     /**
-     *
+     * Register a bot. The Bot Session is started immediately, and may be disconnected by calling close.
      * @param bot
      */
-    public void registerBot(TelegramLongPollingBot bot) throws TelegramApiException {
+    public BotSession registerBot(TelegramLongPollingBot bot) throws TelegramApiException {
         setWebhook(bot.getBotToken());
-        new UpdatesThread(bot.getBotToken(), bot);
+        return new BotSession(bot.getBotToken(), bot);
     }
 
     /**

--- a/src/main/java/org/telegram/telegrambots/updatesreceivers/BotSession.java
+++ b/src/main/java/org/telegram/telegrambots/updatesreceivers/BotSession.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * @brief Thread to request updates with active wait
  * @date 20 of June of 2015
  */
-public class UpdatesThread {
+public class BotSession {
     private static final int SOCKET_TIMEOUT = 30 * 1000;
 
     private final ITelegramLongPollingBot callback;
@@ -40,26 +40,49 @@ public class UpdatesThread {
     private final ConcurrentLinkedDeque<Update> receivedUpdates = new ConcurrentLinkedDeque<>();
     private final String token;
     private int lastReceivedUpdate = 0;
+    private volatile boolean running = true;
+    private volatile CloseableHttpClient httpclient;
 
-    public UpdatesThread(String token, ITelegramLongPollingBot callback) {
+
+    public BotSession(String token, ITelegramLongPollingBot callback) {
         this.token = token;
         this.callback = callback;
         this.readerThread = new ReaderThread();
+        readerThread.setName(callback.getBotUsername() + " Telegram Connection");
         this.readerThread.start();
         this.handlerThread = new HandlerThread();
+        handlerThread.setName(callback.getBotUsername() + " Executor");
         this.handlerThread.start();
+    }
+    
+    public void close()
+    {
+    	running = false;
+    	if(httpclient != null)
+    	{
+    		try
+			{
+				httpclient.close();
+				httpclient = null;
+			} catch (IOException e)
+			{
+				//Ignore it
+			}
+    	}
+    	
     }
 
     private class ReaderThread extends Thread {
-        @Override
+
+		@Override
         public void run() {
             setPriority(Thread.MIN_PRIORITY);
-            while(true) {
+            while(running) {
                 GetUpdates request = new GetUpdates();
                 request.setLimit(100);
                 request.setTimeout(20);
                 request.setOffset(lastReceivedUpdate + 1);
-                CloseableHttpClient httpclient = HttpClientBuilder.create().setSSLHostnameVerifier(new NoopHostnameVerifier()).setConnectionTimeToLive(20, TimeUnit.SECONDS).build();
+                httpclient = HttpClientBuilder.create().setSSLHostnameVerifier(new NoopHostnameVerifier()).setConnectionTimeToLive(20, TimeUnit.SECONDS).build();
                 String url = Constants.BASEURL + token + "/" + GetUpdates.PATH;
                 //config
                 RequestConfig defaultRequestConfig = RequestConfig.custom().build();
@@ -117,7 +140,7 @@ public class UpdatesThread {
         @Override
         public void run() {
             setPriority(Thread.MIN_PRIORITY);
-            while(true) {
+            while(running) {
                 try {
                     Update update = receivedUpdates.pollLast();
                     if (update == null) {


### PR DESCRIPTION
Return a Bot Session Class when registering a Bot that can be closed as
needed
Give Threads a default Name to distinguish them in Debug Mode

Fixes #19 for Long Polling Bots

Four notable changes:

Made registerBot return a BotSession
Renamed UpdatesThread to BotSession
Added a shutdown Method to BotSession
Gave threads meaningful names