### PR TITLE
Changed the json cahed object class to Sticker

### DIFF
--- a/src/main/java/org/telegram/telegrambots/api/objects/inlinequery/result/chached/InlineQueryResultCachedSticker.java
+++ b/src/main/java/org/telegram/telegrambots/api/objects/inlinequery/result/chached/InlineQueryResultCachedSticker.java
@@ -118,10 +118,10 @@ public class InlineQueryResultCachedSticker implements InlineQueryResult {
 
     @Override
     public String toString() {
-        return "InlineQueryResultCachedGif{" +
+        return "InlineQueryResultCachedSticker{" +
                 "type='" + type + '\'' +
                 ", id='" + id + '\'' +
-                ", gifUrl='" + stickerFileId + '\'' +
+                ", sticker_file_id='" + stickerFileId + '\'' +
                 ", inputMessageContent='" + inputMessageContent + '\'' +
                 ", replyMarkup='" + replyMarkup + '\'' +
                 '}';


### PR DESCRIPTION
It was generating a `InlineQueryResultCachedGif` instead of `InlineQueryResultCachedSticker`, producing a wrong behavior.