### PR TITLE
Set UTF-8 character set for reply_markup fields

### DIFF
--- a/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
+++ b/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
@@ -504,7 +504,7 @@ public abstract class AbsSender {
                 builder.addTextBody(SendDocument.CHATID_FIELD, sendDocument.getChatId());
                 builder.addBinaryBody(SendDocument.DOCUMENT_FIELD, new java.io.File(sendDocument.getDocument()), ContentType.APPLICATION_OCTET_STREAM, sendDocument.getDocumentName());
                 if (sendDocument.getReplayMarkup() != null) {
-                    builder.addTextBody(SendDocument.REPLYMARKUP_FIELD, sendDocument.getReplayMarkup().toJson().toString());
+                    builder.addTextBody(SendDocument.REPLYMARKUP_FIELD, sendDocument.getReplayMarkup().toJson().toString(), ContentType.create("text/plain", StandardCharsets.UTF_8));
                 }
                 if (sendDocument.getReplayToMessageId() != null) {
                     builder.addTextBody(SendDocument.REPLYTOMESSAGEID_FIELD, sendDocument.getReplayToMessageId().toString());
@@ -564,7 +564,7 @@ public abstract class AbsSender {
                 builder.addTextBody(SendPhoto.CHATID_FIELD, sendPhoto.getChatId());
                 builder.addBinaryBody(SendPhoto.PHOTO_FIELD, new java.io.File(sendPhoto.getPhoto()), ContentType.APPLICATION_OCTET_STREAM, sendPhoto.getPhotoName());
                 if (sendPhoto.getReplayMarkup() != null) {
-                    builder.addTextBody(SendPhoto.REPLYMARKUP_FIELD, sendPhoto.getReplayMarkup().toJson().toString());
+                    builder.addTextBody(SendPhoto.REPLYMARKUP_FIELD, sendPhoto.getReplayMarkup().toJson().toString(), ContentType.create("text/plain", StandardCharsets.UTF_8));
                 }
                 if (sendPhoto.getReplayToMessageId() != null) {
                     builder.addTextBody(SendPhoto.REPLYTOMESSAGEID_FIELD, sendPhoto.getReplayToMessageId().toString());
@@ -624,7 +624,7 @@ public abstract class AbsSender {
                 builder.addTextBody(SendVideo.CHATID_FIELD, sendVideo.getChatId());
                 builder.addBinaryBody(SendVideo.VIDEO_FIELD, new java.io.File(sendVideo.getVideo()), ContentType.APPLICATION_OCTET_STREAM, sendVideo.getVideoName());
                 if (sendVideo.getReplayMarkup() != null) {
-                    builder.addTextBody(SendVideo.REPLYMARKUP_FIELD, sendVideo.getReplayMarkup().toJson().toString());
+                    builder.addTextBody(SendVideo.REPLYMARKUP_FIELD, sendVideo.getReplayMarkup().toJson().toString(), ContentType.create("text/plain", StandardCharsets.UTF_8));
                 }
                 if (sendVideo.getReplayToMessageId() != null) {
                     builder.addTextBody(SendVideo.REPLYTOMESSAGEID_FIELD, sendVideo.getReplayToMessageId().toString());
@@ -703,7 +703,7 @@ public abstract class AbsSender {
                 builder.addTextBody(SendSticker.CHATID_FIELD, sendSticker.getChatId());
                 builder.addBinaryBody(SendSticker.STICKER_FIELD, new java.io.File(sendSticker.getSticker()), ContentType.APPLICATION_OCTET_STREAM, sendSticker.getStickerName());
                 if (sendSticker.getReplayMarkup() != null) {
-                    builder.addTextBody(SendSticker.REPLYMARKUP_FIELD, sendSticker.getReplayMarkup().toJson().toString());
+                    builder.addTextBody(SendSticker.REPLYMARKUP_FIELD, sendSticker.getReplayMarkup().toJson().toString(), ContentType.create("text/plain", StandardCharsets.UTF_8));
                 }
                 if (sendSticker.getReplayToMessageId() != null) {
                     builder.addTextBody(SendSticker.REPLYTOMESSAGEID_FIELD, sendSticker.getReplayToMessageId().toString());
@@ -765,7 +765,7 @@ public abstract class AbsSender {
                 builder.addTextBody(SendAudio.CHATID_FIELD, sendAudio.getChatId());
                 builder.addBinaryBody(SendAudio.AUDIO_FIELD, new java.io.File(sendAudio.getAudio()), ContentType.create("audio/mpeg"), sendAudio.getAudioName());
                 if (sendAudio.getReplayMarkup() != null) {
-                    builder.addTextBody(SendAudio.REPLYMARKUP_FIELD, sendAudio.getReplayMarkup().toJson().toString());
+                    builder.addTextBody(SendAudio.REPLYMARKUP_FIELD, sendAudio.getReplayMarkup().toJson().toString(), ContentType.create("text/plain", StandardCharsets.UTF_8));
                 }
                 if (sendAudio.getReplayToMessageId() != null) {
                     builder.addTextBody(SendAudio.REPLYTOMESSAGEID_FIELD, sendAudio.getReplayToMessageId().toString());
@@ -847,7 +847,7 @@ public abstract class AbsSender {
                 builder.addTextBody(SendVoice.CHATID_FIELD, sendVoice.getChatId());
                 builder.addBinaryBody(SendVoice.AUDIO_FIELD, new java.io.File(sendVoice.getAudio()), ContentType.create("audio/ogg"), sendVoice.getVoiceName());
                 if (sendVoice.getReplayMarkup() != null) {
-                    builder.addTextBody(SendVoice.REPLYMARKUP_FIELD, sendVoice.getReplayMarkup().toJson().toString());
+                    builder.addTextBody(SendVoice.REPLYMARKUP_FIELD, sendVoice.getReplayMarkup().toJson().toString(), ContentType.create("text/plain", StandardCharsets.UTF_8));
                 }
                 if (sendVoice.getReplayToMessageId() != null) {
                     builder.addTextBody(SendVoice.REPLYTOMESSAGEID_FIELD, sendVoice.getReplayToMessageId().toString());


### PR DESCRIPTION
Set UTF-8 character set for reply_markup field in sendDocument(), sendPhoto(), sendVideo(), sendSticker(), sendAudio(), sendVoice() methods