### PR TITLE
In some specific cases you got a StringIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/telegram/telegrambots/api/objects/MessageEntity.java
+++ b/src/main/java/org/telegram/telegrambots/api/objects/MessageEntity.java
@@ -93,7 +93,7 @@ public class MessageEntity implements IBotApiObject {
     }
 
     protected void computeText(String message) {
-        text = message.substring(offset, offset + length);
+        text = message.substring(offset, message.length());
     }
 
     @Override


### PR DESCRIPTION
IMO the length should be the message's length.
SEVERE: BOTSESSION
java.lang.StringIndexOutOfBoundsException: String index out of range: 66
  at java.lang.String.substring(String.java:1963)
  at org.telegram.telegrambots.api.objects.MessageEntity.computeText(MessageEntity.java:96)
  at org.telegram.telegrambots.api.objects.Message.lambda$new$0(Message.java:264)
  at java.util.ArrayList.forEach(ArrayList.java:1249)
  at org.telegram.telegrambots.api.objects.Message.<init😠Message.java:264)
  at org.telegram.telegrambots.api.objects.Update.<init😠Update.java:50)
  at org.telegram.telegrambots.updatesreceivers.BotSession$ReaderThread.run(BotSession.java:124)

To reproduce just use this message:
`JOptionPane jop = null;
null.showMessageDialog("bla bla bla");`