### PR TITLE
Fixing sending Files through InputStream causing exceptions.

### DIFF
--- a/src/main/java/org/telegram/telegrambots/api/methods/send/SendAudio.java
+++ b/src/main/java/org/telegram/telegrambots/api/methods/send/SendAudio.java
@@ -4,6 +4,7 @@ import org.telegram.telegrambots.api.objects.replykeyboard.ReplyKeyboard;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Objects;
 
 /**
  * @author Ruben Bermudez
@@ -111,7 +112,10 @@ public class SendAudio {
         return this;
     }
 
-    public SendAudio setNewAudio(InputStream inputStream) {
+    public SendAudio setNewAudio(String audioName, InputStream inputStream) {
+    	Objects.requireNonNull(audioName, "audioName cannot be null!");
+    	Objects.requireNonNull(inputStream, "inputStream cannot be null!");
+    	this.audioName = audioName;
         this.isNewAudio = true;
         this.newAudioStream = inputStream;
         return this;

--- a/src/main/java/org/telegram/telegrambots/api/methods/send/SendDocument.java
+++ b/src/main/java/org/telegram/telegrambots/api/methods/send/SendDocument.java
@@ -4,6 +4,7 @@ import org.telegram.telegrambots.api.objects.replykeyboard.ReplyKeyboard;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Objects;
 
 /**
  * @author Ruben Bermudez
@@ -93,12 +94,10 @@ public class SendDocument {
         return this;
     }
 
-    /**
-     * Use this method to set the document to a new file
-     *
-     * @param inputStream New document file
-     */
-    public SendDocument setNewDocument(InputStream inputStream) {
+    public SendDocument setNewDocument(String documentName, InputStream inputStream) {
+    	Objects.requireNonNull(documentName, "documentName cannot be null!");
+    	Objects.requireNonNull(inputStream, "inputStream cannot be null!");
+    	this.documentName = documentName;
         this.isNewDocument = true;
         this.newDocumentStream = inputStream;
         return this;

--- a/src/main/java/org/telegram/telegrambots/api/methods/send/SendPhoto.java
+++ b/src/main/java/org/telegram/telegrambots/api/methods/send/SendPhoto.java
@@ -4,6 +4,7 @@ import org.telegram.telegrambots.api.objects.replykeyboard.ReplyKeyboard;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Objects;
 
 /**
  * @author Ruben Bermudez
@@ -171,7 +172,10 @@ public class SendPhoto {
         return this;
     }
 
-    public SendPhoto setNewPhoto(InputStream inputStream) {
+    public SendPhoto setNewPhoto(String photoName, InputStream inputStream) {
+    	Objects.requireNonNull(photoName, "photoName cannot be null!");
+    	Objects.requireNonNull(inputStream, "inputStream cannot be null!");
+    	this.photoName = photoName;
         this.newPhotoStream = inputStream;
         this.isNewPhoto = true;
         return this;

--- a/src/main/java/org/telegram/telegrambots/api/methods/send/SendSticker.java
+++ b/src/main/java/org/telegram/telegrambots/api/methods/send/SendSticker.java
@@ -4,6 +4,7 @@ import org.telegram.telegrambots.api.objects.replykeyboard.ReplyKeyboard;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Objects;
 
 /**
  * @author Ruben Bermudez
@@ -130,7 +131,10 @@ public class SendSticker {
         return this;
     }
 
-    public SendSticker setNewSticker(InputStream inputStream) {
+    public SendSticker setNewSticker(String stickerName, InputStream inputStream) {
+    	Objects.requireNonNull(stickerName, "stickerName cannot be null!");
+    	Objects.requireNonNull(inputStream, "inputStream cannot be null!");
+    	this.stickerName = stickerName;
         this.isNewSticker = true;
         this.newStickerStream = inputStream;
         return this;

--- a/src/main/java/org/telegram/telegrambots/api/methods/send/SendVideo.java
+++ b/src/main/java/org/telegram/telegrambots/api/methods/send/SendVideo.java
@@ -4,6 +4,7 @@ import org.telegram.telegrambots.api.objects.replykeyboard.ReplyKeyboard;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Objects;
 
 /**
  * @author Ruben Bermudez
@@ -205,7 +206,10 @@ public class SendVideo {
         return this;
     }
 
-    public SendVideo setNewVideo(InputStream inputStream) {
+    public SendVideo setNewVideo(String videoName, InputStream inputStream) {
+    	Objects.requireNonNull(videoName, "videoName cannot be null!");
+    	Objects.requireNonNull(inputStream, "inputStream cannot be null!");
+    	this.videoName = videoName;
         this.isNewVideo = true;
         this.newVideoStream = inputStream;
         return this;

--- a/src/main/java/org/telegram/telegrambots/api/methods/send/SendVoice.java
+++ b/src/main/java/org/telegram/telegrambots/api/methods/send/SendVoice.java
@@ -4,6 +4,7 @@ import org.telegram.telegrambots.api.objects.replykeyboard.ReplyKeyboard;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Objects;
 
 /**
  * @author Ruben Bermudez
@@ -144,7 +145,10 @@ public class SendVoice {
         return this;
     }
 
-    public SendVoice setNewVoice(InputStream inputStream) {
+    public SendVoice setNewVoice(String voiceName, InputStream inputStream) {
+    	Objects.requireNonNull(voiceName, "voiceName cannot be null!");
+    	Objects.requireNonNull(inputStream, "inputStream cannot be null!");
+    	this.voiceName = voiceName;
         this.isNewVoice = true;
         this.newVoiceStream = inputStream;
         return this;

--- a/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
+++ b/src/main/java/org/telegram/telegrambots/bots/AbsSender.java
@@ -519,7 +519,7 @@ public abstract class AbsSender {
                 if (sendDocument.getNewDocumentFile() != null) {
                     builder.addBinaryBody(SendDocument.DOCUMENT_FIELD, sendDocument.getNewDocumentFile());
                 } else if (sendDocument.getNewDocumentStream() != null) {
-                    builder.addBinaryBody(SendDocument.DOCUMENT_FIELD, sendDocument.getNewDocumentStream());
+                    builder.addBinaryBody(SendDocument.DOCUMENT_FIELD, sendDocument.getNewDocumentStream(), ContentType.APPLICATION_OCTET_STREAM, sendDocument.getDocumentName());
                 } else {
                     builder.addBinaryBody(SendDocument.DOCUMENT_FIELD, new java.io.File(sendDocument.getDocument()), ContentType.APPLICATION_OCTET_STREAM, sendDocument.getDocumentName());
                 }
@@ -585,7 +585,7 @@ public abstract class AbsSender {
                 if (sendPhoto.getNewPhotoFile() != null) {
                     builder.addBinaryBody(SendPhoto.PHOTO_FIELD, sendPhoto.getNewPhotoFile());
                 } else if (sendPhoto.getNewPhotoStream() != null) {
-                    builder.addBinaryBody(SendPhoto.PHOTO_FIELD, sendPhoto.getNewPhotoStream());
+                    builder.addBinaryBody(SendPhoto.PHOTO_FIELD, sendPhoto.getNewPhotoStream(), ContentType.APPLICATION_OCTET_STREAM, sendPhoto.getPhotoName());
                 } else {
                     builder.addBinaryBody(SendPhoto.PHOTO_FIELD, new java.io.File(sendPhoto.getPhoto()), ContentType.APPLICATION_OCTET_STREAM, sendPhoto.getPhotoName());
                 }
@@ -651,7 +651,7 @@ public abstract class AbsSender {
                 if (sendVideo.getNewVideoFile() != null) {
                     builder.addBinaryBody(SendVideo.VIDEO_FIELD, sendVideo.getNewVideoFile());
                 } else if (sendVideo.getNewVideoStream() != null) {
-                    builder.addBinaryBody(SendVideo.VIDEO_FIELD, sendVideo.getNewVideoStream());
+                    builder.addBinaryBody(SendVideo.VIDEO_FIELD, sendVideo.getNewVideoStream(), ContentType.APPLICATION_OCTET_STREAM, sendVideo.getVideoName());
                 } else {
                     builder.addBinaryBody(SendVideo.VIDEO_FIELD, new java.io.File(sendVideo.getVideo()), ContentType.APPLICATION_OCTET_STREAM, sendVideo.getVideoName());
                 }
@@ -736,7 +736,7 @@ public abstract class AbsSender {
                 if (sendSticker.getNewStickerFile() != null) {
                     builder.addBinaryBody(SendSticker.STICKER_FIELD, sendSticker.getNewStickerFile());
                 } else if (sendSticker.getNewStickerStream() != null) {
-                    builder.addBinaryBody(SendSticker.STICKER_FIELD, sendSticker.getNewStickerStream());
+                    builder.addBinaryBody(SendSticker.STICKER_FIELD, sendSticker.getNewStickerStream(), ContentType.APPLICATION_OCTET_STREAM, sendSticker.getStickerName());
                 } else {
                     builder.addBinaryBody(SendSticker.STICKER_FIELD, new java.io.File(sendSticker.getSticker()), ContentType.APPLICATION_OCTET_STREAM, sendSticker.getStickerName());
                 }
@@ -804,7 +804,7 @@ public abstract class AbsSender {
                 if (sendAudio.getNewAudioFile() != null) {
                     builder.addBinaryBody(SendAudio.AUDIO_FIELD, sendAudio.getNewAudioFile());
                 } else if (sendAudio.getNewAudioStream() != null) {
-                    builder.addBinaryBody(SendAudio.AUDIO_FIELD, sendAudio.getNewAudioStream());
+                    builder.addBinaryBody(SendAudio.AUDIO_FIELD, sendAudio.getNewAudioStream(), ContentType.APPLICATION_OCTET_STREAM, sendAudio.getAudioName());
                 } else {
                     builder.addBinaryBody(SendAudio.AUDIO_FIELD, new java.io.File(sendAudio.getAudio()), ContentType.create("audio/mpeg"), sendAudio.getAudioName());
                 }
@@ -893,7 +893,7 @@ public abstract class AbsSender {
                 if (sendVoice.getNewVoiceFile() != null) {
                     builder.addBinaryBody(SendVoice.VOICE_FIELD, sendVoice.getNewVoiceFile());
                 } else if (sendVoice.getNewVoiceStream() != null) {
-                    builder.addBinaryBody(SendVoice.VOICE_FIELD, sendVoice.getNewVoiceStream());
+                    builder.addBinaryBody(SendVoice.VOICE_FIELD, sendVoice.getNewVoiceStream(), ContentType.APPLICATION_OCTET_STREAM, sendVoice.getVoiceName());
                 } else {
                     builder.addBinaryBody(SendVoice.VOICE_FIELD, new java.io.File(sendVoice.getVoice()), ContentType.create("audio/ogg"), sendVoice.getVoiceName());
                 }


### PR DESCRIPTION
- Added proper methods to send Audio/Document/Photo/Sticker/Video/Voice
through InputStream as it Telegram API requires file name to be
specified.

- Dropped all old methods since they wasn't working at all, please update to the new ones!