### PR TITLE
Add 'ConversationCommand'.

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingConversationBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingConversationBot.java
@@ -1,0 +1,188 @@
+package org.telegram.telegrambots.bots;
+
+import org.telegram.telegrambots.ApiContext;
+import org.telegram.telegrambots.api.objects.Chat;
+import org.telegram.telegrambots.api.objects.Message;
+import org.telegram.telegrambots.api.objects.Update;
+import org.telegram.telegrambots.api.objects.User;
+import org.telegram.telegrambots.bots.commands.BotCommand;
+import org.telegram.telegrambots.bots.commands.conversation.ConversationCommand;
+import org.telegram.telegrambots.bots.commands.conversation.ConversationLockHolder;
+import org.telegram.telegrambots.bots.commands.conversation.ConversationRegistry;
+import org.telegram.telegrambots.bots.commands.conversation.IConversationRegistry;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/**
+ * The TelegramLongPollingConversationBot class.
+ * Implementation of LongPollingBot for {@link ConversationCommand}.
+ *
+ * @author jrrakh
+ *         12/26/16
+ */
+public abstract class TelegramLongPollingConversationBot
+    extends TelegramLongPollingBot implements IConversationRegistry {
+
+    private static final String DEFAULT_CANCEL_COMMAND_IDENTIFIER = "cancel";
+    private IConversationRegistry commandRegistry;
+    private ConversationLockHolder conversationHolderLock;
+
+    /**
+     * Instantiates a new Telegram long polling conversation bot.
+     */
+    public TelegramLongPollingConversationBot() {
+        this(ApiContext.getInstance(DefaultBotOptions.class));
+    }
+
+    /**
+     * Instantiates a new Telegram long polling conversation bot.
+     *
+     * @param options the options
+     */
+    public TelegramLongPollingConversationBot(DefaultBotOptions options) {
+        this(options, true);
+    }
+
+    /**
+     * Instantiates a new Telegram long polling conversation bot.
+     *
+     * @param options                   the options
+     * @param allowCommandsWithUsername the allow commands with username
+     */
+    public TelegramLongPollingConversationBot(DefaultBotOptions options, boolean allowCommandsWithUsername) {
+        super(options);
+        this.commandRegistry = new ConversationRegistry(allowCommandsWithUsername, getBotUsername());
+        this.conversationHolderLock = new ConversationLockHolder();
+    }
+
+
+    @Override
+    public void onUpdateReceived(Update update) {
+        if (update.hasMessage()) {
+            Message message = update.getMessage();
+            Chat chat = message.getChat();
+            User user = message.getFrom();
+            UpdateData updateData = new UpdateData(message.getText());
+            if (message.isCommand()) {
+                if (message.hasText()) {
+                    if (updateData.isTextStartWithCommand()) {
+                        if (checkForCancelAndExecute(chat, user, updateData)) {
+                            return;
+                        }
+                        if (checkForCommandAndExecute(chat, user, updateData)) {
+                            return;
+                        }
+                        if (checkForWarningAndExecute(chat, user, updateData)) {
+                            return;
+                        }
+                    }
+                }
+            }
+            checkForUpdateAndExecute(chat, user, updateData);
+        }
+    }
+
+    private void checkForUpdateAndExecute(Chat chat, User user, UpdateData updateData) {
+        if (conversationHolderLock.isLocked(chat.getId())) {
+            ConversationCommand lockedConversation = conversationHolderLock.getLockedConversation(chat.getId());
+            lockedConversation.onUpdate(this, user, chat, updateData.getArguments());
+        }
+    }
+
+    private boolean checkForWarningAndExecute(Chat chat, User user, UpdateData updateData) {
+        ConversationCommand command = commandRegistry.getRegisteredCommand(updateData.getCommandIdentifier());
+        if (command != null && updateData.getText().startsWith(BotCommand.COMMAND_INIT_CHARACTER)) {
+            command.warning(this, user, chat, updateData.getArguments());
+            return true;
+        }
+        return false;
+    }
+
+    private boolean checkForCommandAndExecute(Chat chat, User user, UpdateData updateData) {
+        ConversationCommand command = commandRegistry.getRegisteredCommand(updateData.getCommandIdentifier());
+        if (command != null) {
+            if (!conversationHolderLock.isLocked(chat.getId())) {
+                conversationHolderLock.lock(chat.getId(), command);
+                command.execute(this, user, chat, updateData.getArguments());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean checkForCancelAndExecute(Chat chat, User user, UpdateData updateData) {
+        if (updateData.getCommandIdentifier().equals(DEFAULT_CANCEL_COMMAND_IDENTIFIER)
+            && conversationHolderLock.isLocked(chat.getId())) {
+            conversationHolderLock.getLockedConversation(chat.getId())
+                .cancel(this, user, chat, updateData.getArguments());
+            conversationHolderLock.unlock(chat.getId());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void registerDefaultAction(BiConsumer<AbsSender, Message> defaultConsumer) {
+        commandRegistry.registerDefaultAction(defaultConsumer);
+    }
+
+    @Override
+    public boolean register(ConversationCommand conversationCommand) {
+        return commandRegistry.register(conversationCommand);
+    }
+
+    @Override
+    public boolean deregister(ConversationCommand conversationCommand) {
+        return commandRegistry.deregister(conversationCommand);
+    }
+
+    @Override
+    public void registerAll(List<ConversationCommand> conversationCommands) {
+        commandRegistry.registerAll(conversationCommands);
+
+    }
+
+    @Override
+    public void deregisterAll(List<ConversationCommand> conversationCommands) {
+        commandRegistry.deregisterAll(conversationCommands);
+    }
+
+    @Override
+    public List<ConversationCommand> getRegisteredCommands() {
+        return commandRegistry.getRegisteredCommands();
+    }
+
+    @Override
+    public ConversationCommand getRegisteredCommand(String commandIdentifier) {
+        return commandRegistry.getRegisteredCommand(commandIdentifier);
+    }
+
+    private final class UpdateData {
+        private final String text;
+        private final String messageBody;
+
+        private UpdateData(String text) {
+            this.text = text;
+            this.messageBody = text.substring(1);
+        }
+
+        private String getText() {
+            return text;
+        }
+
+        private String[] getArguments() {
+            String[] splittedMessage = messageBody.split(BotCommand.COMMAND_PARAMETER_SEPARATOR);
+            return Arrays.copyOfRange(splittedMessage, 1, splittedMessage.length);
+        }
+
+        private String getCommandIdentifier() {
+            return messageBody.split(BotCommand.COMMAND_PARAMETER_SEPARATOR)[0];
+        }
+
+        private boolean isTextStartWithCommand() {
+            return text.startsWith(BotCommand.COMMAND_INIT_CHARACTER);
+        }
+    }
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/commands/conversation/ConversationCommand.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/commands/conversation/ConversationCommand.java
@@ -1,0 +1,56 @@
+package org.telegram.telegrambots.bots.commands.conversation;
+
+import org.telegram.telegrambots.api.objects.Chat;
+import org.telegram.telegrambots.api.objects.User;
+import org.telegram.telegrambots.bots.AbsSender;
+import org.telegram.telegrambots.bots.commands.BotCommand;
+
+/**
+ * The ConversationCommand class.
+ * Type of command which provide ability to create conversation with bot.
+ * @author jrrakh
+ *         12/26/16
+ */
+public abstract class ConversationCommand extends BotCommand {
+
+    /**
+     * Construct a command
+     *
+     * @param commandIdentifier the unique identifier of this command (e.g. the command string to
+     *                          enter into chat)
+     * @param description       the description of this command
+     */
+    public ConversationCommand(String commandIdentifier, String description) {
+        super(commandIdentifier, description);
+    }
+
+    /**
+     * Execute on update, when message to bot sent.
+     *
+     * @param absSender absSender to send messages over
+     * @param user      the user who sent the command
+     * @param chat      the chat, to be able to send replies
+     * @param arguments passed arguments
+     */
+    public abstract void onUpdate(AbsSender absSender, User user, Chat chat, String[] arguments);
+
+    /**
+     * Execute when user cancel conversation command.
+     *
+     * @param absSender absSender to send messages over
+     * @param user      the user who sent the command
+     * @param chat      the chat, to be able to send replies
+     * @param arguments passed arguments
+     */
+    public abstract void cancel(AbsSender absSender, User user, Chat chat, String[] arguments);
+
+    /**
+     * Execute if user try to execute another command while conversation command in process.
+     *
+     * @param absSender absSender to send messages over
+     * @param user      the user who sent the command
+     * @param chat      the chat, to be able to send replies
+     * @param arguments passed arguments
+     */
+    public abstract void warning(AbsSender absSender, User user, Chat chat, String[] arguments);
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/commands/conversation/ConversationLockHolder.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/commands/conversation/ConversationLockHolder.java
@@ -1,0 +1,34 @@
+package org.telegram.telegrambots.bots.commands.conversation;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The ConversationLockHolder class.
+ * Keep lock for chat and {@link ConversationCommand}.
+ *
+ * @author jrrakh
+ *         12/26/16
+ */
+public final class ConversationLockHolder {
+    private Map<Long, ConversationCommand> lock = new ConcurrentHashMap<>();
+
+
+    public boolean isLocked(long chatId) {
+        return lock.containsKey(chatId);
+    }
+
+    public void lock(long chatId, ConversationCommand command) {
+        if (!isLocked(chatId)) {
+            lock.put(chatId, command);
+        }
+    }
+
+    public void unlock(long chatId) {
+        lock.remove(chatId);
+    }
+
+    public ConversationCommand getLockedConversation(long chatId) {
+        return lock.get(chatId);
+    }
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/commands/conversation/ConversationRegistry.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/commands/conversation/ConversationRegistry.java
@@ -1,0 +1,73 @@
+package org.telegram.telegrambots.bots.commands.conversation;
+
+import com.google.common.collect.Lists;
+import org.telegram.telegrambots.api.objects.Message;
+import org.telegram.telegrambots.bots.AbsSender;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/** The ConversationRegistry class for {@link ConversationCommand}.
+ * @author jrrakh
+ *         12/26/16
+ */
+public class ConversationRegistry implements IConversationRegistry {
+    private final Map<String, ConversationCommand> commandRegistryMap = new HashMap<>();
+    private final boolean allowCommandsWithUsername;
+    private final String botUsername;
+    private BiConsumer<AbsSender, Message> defaultConsumer;
+
+    /**
+     * Creates a Command registry
+     *
+     * @param allowCommandsWithUsername True to allow commands with username, false otherwise
+     * @param botUsername               Bot username
+     */
+    public ConversationRegistry(boolean allowCommandsWithUsername, String botUsername) {
+        this.allowCommandsWithUsername = allowCommandsWithUsername;
+        this.botUsername = botUsername;
+    }
+
+    @Override
+    public void registerDefaultAction(BiConsumer<AbsSender, Message> defaultConsumer) {
+        this.defaultConsumer = defaultConsumer;
+    }
+
+    @Override
+    public boolean register(ConversationCommand conversationCommand) {
+        if (commandRegistryMap.containsKey(conversationCommand.getCommandIdentifier())) {
+            return false;
+        }
+        commandRegistryMap.put(conversationCommand.getCommandIdentifier(), conversationCommand);
+        return true;
+    }
+
+    @Override
+    public boolean deregister(ConversationCommand conversationCommand) {
+        return commandRegistryMap.remove(conversationCommand.getCommandIdentifier()) != null;
+    }
+
+    @Override
+    public void registerAll(List<ConversationCommand> conversationCommands) {
+        conversationCommands
+            .forEach(command -> commandRegistryMap.put(command.getCommandIdentifier(), command));
+    }
+
+    @Override
+    public void deregisterAll(List<ConversationCommand> conversationCommands) {
+        conversationCommands
+            .forEach(command -> commandRegistryMap.remove(command.getCommandIdentifier()));
+    }
+
+    @Override
+    public List<ConversationCommand> getRegisteredCommands() {
+        return Lists.newArrayList(commandRegistryMap.values());
+    }
+
+    @Override
+    public ConversationCommand getRegisteredCommand(String commandIdentifier) {
+        return commandRegistryMap.get(commandIdentifier);
+    }
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/commands/conversation/IConversationRegistry.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/commands/conversation/IConversationRegistry.java
@@ -1,0 +1,69 @@
+package org.telegram.telegrambots.bots.commands.conversation;
+
+import org.telegram.telegrambots.api.objects.Message;
+import org.telegram.telegrambots.bots.AbsSender;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/**
+ * The interface Conversation registry for {@link ConversationCommand}.
+ *
+ * @author jrrakh
+ *         12/26/16
+ */
+public interface IConversationRegistry {
+
+    /**
+     * Register default action.
+     *
+     * @param defaultConsumer the default consumer
+     */
+    void registerDefaultAction(BiConsumer<AbsSender, Message> defaultConsumer);
+
+    /**
+     * Register.
+     *
+     * @param conversationCommand the conversation command
+     * @return the boolean
+     */
+    boolean register(ConversationCommand conversationCommand);
+
+    /**
+     * Deregister.
+     *
+     * @param conversationCommand the conversation command
+     * @return the boolean
+     */
+    boolean deregister(ConversationCommand conversationCommand);
+
+    /**
+     * Register all.
+     *
+     * @param conversationCommands the conversation commands
+     */
+    void registerAll(List<ConversationCommand> conversationCommands);
+
+    /**
+     * Deregister all.
+     *
+     * @param conversationCommands the conversation commands
+     */
+    void deregisterAll(List<ConversationCommand> conversationCommands);
+
+    /**
+     * Gets registered commands.
+     *
+     * @return the registered commands
+     */
+    List<ConversationCommand> getRegisteredCommands();
+
+    /**
+     * Gets registered command.
+     *
+     * @param commandIdentifier the command identifier
+     * @return the regisetred command
+     */
+    ConversationCommand getRegisteredCommand(String commandIdentifier);
+
+}


### PR DESCRIPTION
Add 'ConversationCommand' command type and LongPolling bot impl for this type of command.
Allow developer to create commands as 'dialog' with bot, define some context for each of them.

- Execute command
- Receive update for this command and work with own context in scope of this command.
- Don't allow (or allow, up to you) user to execute another commands and show him warning.
- Interrupt current command with '/cancel' command.

Please review @rubenlagus