### PR TITLE
ExecutorService decoupled

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -1,7 +1,6 @@
 package org.telegram.telegrambots.bots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
@@ -42,7 +41,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -63,7 +61,7 @@ public abstract class DefaultAbsSender extends AbsSender {
 
     protected DefaultAbsSender(DefaultBotOptions options) {
         super();
-        this.exe = Executors.newFixedThreadPool(options.getMaxThreads());
+        exe = options.getExecutorServiceSupplier().get();
         this.options = options;
         httpclient = HttpClientBuilder.create()
                 .setSSLHostnameVerifier(new NoopHostnameVerifier())
@@ -680,5 +678,14 @@ public abstract class DefaultAbsSender extends AbsSender {
 
     private String getBaseUrl() {
         return ApiConstants.BASE_URL + getBotToken() + "/";
+    }
+
+    /**
+     * Notice protected mod as this method should be called by concrete implementors
+     */
+    protected void dispose() {
+        if (exe!=null) {
+            exe.shutdown();
+        }
     }
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
@@ -5,6 +5,12 @@ import org.telegram.telegrambots.generics.BotOptions;
 import org.telegram.telegrambots.updatesreceivers.ExponentialBackOff;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Ruben Bermudez
@@ -13,17 +19,21 @@ import java.util.List;
  * @date 21 of July of 2016
  */
 public class DefaultBotOptions implements BotOptions {
-    private int maxThreads; ///< Max number of threads used for async methods executions (default 1)
+    private int maxThreads = 1; ///< Max number of threads used for async methods executions (default 1)
+    /**
+     * Custom executorService factory
+     */
+    private Supplier<ExecutorService> executorServiceSupplier = () -> Executors.newFixedThreadPool(maxThreads);
     private RequestConfig requestConfig;
     private ExponentialBackOff exponentialBackOff;
     private Integer maxWebhookConnections;
     private List<String> allowedUpdates;
 
-    public DefaultBotOptions() {
-        maxThreads = 1;
-    }
+    public DefaultBotOptions() {}
 
     public void setMaxThreads(int maxThreads) {
+        boolean inRange = maxThreads > 0 && maxThreads <= Runtime.getRuntime().availableProcessors();
+        checkArgument(inRange, "Given arg %d exceeds range of (0, availablProcessors]", maxThreads);
         this.maxThreads = maxThreads;
     }
 
@@ -69,5 +79,14 @@ public class DefaultBotOptions implements BotOptions {
      */
     public void setExponentialBackOff(ExponentialBackOff exponentialBackOff) {
         this.exponentialBackOff = exponentialBackOff;
+    }
+
+    public Supplier<ExecutorService> getExecutorServiceSupplier() {
+        return executorServiceSupplier;
+    }
+
+    public void setExecutorServiceSupplier(Supplier<ExecutorService> executorServiceSupplier) {
+        checkNotNull(executorServiceSupplier);
+        this.executorServiceSupplier = executorServiceSupplier;
     }
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
@@ -56,4 +56,9 @@ public abstract class TelegramLongPollingBot extends DefaultAbsSender implements
             throw new TelegramApiRequestException("Error executing setWebook method", e);
         }
     }
+
+    @Override
+    public void onClosing() {
+        dispose();
+    }
 }


### PR DESCRIPTION
Sometimes you need to customize executorService a little. Current impl is just hardcoded. And created in constructor executorService was not being released when closing a bot session.
Also possibly `HandlerThread` and `ReaderThread` should be refactored to runnables and be submitted to separate executorService.