### PR TITLE
Fix API error on UTF-8 encoded performers / titles

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -1,6 +1,7 @@
 package org.telegram.telegrambots.bots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
@@ -565,10 +566,10 @@ public abstract class DefaultAbsSender extends AbsSender {
                     builder.addTextBody(SendAudio.REPLYTOMESSAGEID_FIELD, sendAudio.getReplyToMessageId().toString());
                 }
                 if (sendAudio.getPerformer() != null) {
-                    builder.addTextBody(SendAudio.PERFOMER_FIELD, sendAudio.getPerformer());
+                    builder.addTextBody(SendAudio.PERFOMER_FIELD, sendAudio.getPerformer(), TEXT_PLAIN_CONTENT_TYPE);
                 }
                 if (sendAudio.getTitle() != null) {
-                    builder.addTextBody(SendAudio.TITLE_FIELD, sendAudio.getTitle());
+                    builder.addTextBody(SendAudio.TITLE_FIELD, sendAudio.getTitle(), TEXT_PLAIN_CONTENT_TYPE);
                 }
                 if(sendAudio.getDuration() != null){
                     builder.addTextBody(SendAudio.DURATION_FIELD, sendAudio.getDuration().toString());


### PR DESCRIPTION
Sending an UTF-8 encoded string as an Audio's title or performer would result in the following error: `org.telegram.telegrambots.exceptions.TelegramApiRequestException: Error sending audio: [400] Bad Request: audio title must be encoded in UTF-8`. 

This is because the default `ContentType` in `addTextBody` is a `ContentType.DEFAULT_TEXT`, which has Charset `ISO_8859_1`.

This fix sets the type to `TEXT_PLAIN_CONTENT_TYPE`.