### PR TITLE
Fix API error on UTF-8 encoded performers / titles

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -565,10 +565,10 @@ public abstract class DefaultAbsSender extends AbsSender {
                     builder.addTextBody(SendAudio.REPLYTOMESSAGEID_FIELD, sendAudio.getReplyToMessageId().toString());
                 }
                 if (sendAudio.getPerformer() != null) {
-                    builder.addTextBody(SendAudio.PERFOMER_FIELD, sendAudio.getPerformer());
+                    builder.addTextBody(SendAudio.PERFOMER_FIELD, sendAudio.getPerformer(), TEXT_PLAIN_CONTENT_TYPE);
                 }
                 if (sendAudio.getTitle() != null) {
-                    builder.addTextBody(SendAudio.TITLE_FIELD, sendAudio.getTitle());
+                    builder.addTextBody(SendAudio.TITLE_FIELD, sendAudio.getTitle(), TEXT_PLAIN_CONTENT_TYPE);
                 }
                 if(sendAudio.getDuration() != null){
                     builder.addTextBody(SendAudio.DURATION_FIELD, sendAudio.getDuration().toString());

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -577,7 +577,7 @@ public abstract class DefaultAbsSender extends AbsSender {
                     builder.addTextBody(SendAudio.DISABLENOTIFICATION_FIELD, sendAudio.getDisableNotification().toString());
                 }
                 if (sendAudio.getCaption() != null) {
-                    builder.addTextBody(SendAudio.CAPTION_FIELD, sendAudio.getCaption());
+                    builder.addTextBody(SendAudio.CAPTION_FIELD, sendAudio.getCaption(), TEXT_PLAIN_CONTENT_TYPE);
                 }
                 HttpEntity multipart = builder.build();
                 httppost.setEntity(multipart);
@@ -660,7 +660,7 @@ public abstract class DefaultAbsSender extends AbsSender {
                     builder.addTextBody(SendVoice.DURATION_FIELD, sendVoice.getDuration().toString());
                 }
                 if (sendVoice.getCaption() != null) {
-                    builder.addTextBody(SendVoice.CAPTION_FIELD, sendVoice.getCaption());
+                    builder.addTextBody(SendVoice.CAPTION_FIELD, sendVoice.getCaption(), TEXT_PLAIN_CONTENT_TYPE);
                 }
                 HttpEntity multipart = builder.build();
                 httppost.setEntity(multipart);


### PR DESCRIPTION
Sending an UTF-8 encoded string as an Audio's title or performer would result in the following error: `org.telegram.telegrambots.exceptions.TelegramApiRequestException: Error sending audio: [400] Bad Request: audio title must be encoded in UTF-8`. 

This is because the default `ContentType` in `addTextBody` is a `ContentType.DEFAULT_TEXT`, which has Charset `ISO_8859_1`.

This fix sets the type to `TEXT_PLAIN_CONTENT_TYPE`.