### PR TITLE
Explicit Contenttype for textBody

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -187,7 +187,7 @@ public abstract class DefaultAbsSender extends AbsSender {
             httppost.setConfig(requestConfig);
 
             MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-            builder.addTextBody(SendDocument.CHATID_FIELD, sendDocument.getChatId());
+            builder.addTextBody(SendDocument.CHATID_FIELD, sendDocument.getChatId(), TEXT_PLAIN_CONTENT_TYPE);
             if (sendDocument.isNewDocument()) {
                 if (sendDocument.getNewDocumentFile() != null) {
                     builder.addBinaryBody(SendDocument.DOCUMENT_FIELD, sendDocument.getNewDocumentFile());
@@ -197,19 +197,19 @@ public abstract class DefaultAbsSender extends AbsSender {
                     builder.addBinaryBody(SendDocument.DOCUMENT_FIELD, new java.io.File(sendDocument.getDocument()), ContentType.APPLICATION_OCTET_STREAM, sendDocument.getDocumentName());
                 }
             } else {
-                builder.addTextBody(SendDocument.DOCUMENT_FIELD, sendDocument.getDocument());
+                builder.addTextBody(SendDocument.DOCUMENT_FIELD, sendDocument.getDocument(), TEXT_PLAIN_CONTENT_TYPE);
             }
             if (sendDocument.getReplyMarkup() != null) {
                 builder.addTextBody(SendDocument.REPLYMARKUP_FIELD, objectMapper.writeValueAsString(sendDocument.getReplyMarkup()), TEXT_PLAIN_CONTENT_TYPE);
             }
             if (sendDocument.getReplyToMessageId() != null) {
-                builder.addTextBody(SendDocument.REPLYTOMESSAGEID_FIELD, sendDocument.getReplyToMessageId().toString());
+                builder.addTextBody(SendDocument.REPLYTOMESSAGEID_FIELD, sendDocument.getReplyToMessageId().toString(), TEXT_PLAIN_CONTENT_TYPE);
             }
             if (sendDocument.getCaption() != null) {
                 builder.addTextBody(SendDocument.CAPTION_FIELD, sendDocument.getCaption(), TEXT_PLAIN_CONTENT_TYPE);
             }
             if (sendDocument.getDisableNotification() != null) {
-                builder.addTextBody(SendDocument.DISABLENOTIFICATION_FIELD, sendDocument.getDisableNotification().toString());
+                builder.addTextBody(SendDocument.DISABLENOTIFICATION_FIELD, sendDocument.getDisableNotification().toString(), TEXT_PLAIN_CONTENT_TYPE);
             }
             HttpEntity multipart = builder.build();
             httppost.setEntity(multipart);


### PR DESCRIPTION
Could you consider the problem with encoding in file names with Cyrillic characters
```
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "POST /bot261418456:AAFP5kZe9xzOszfc92rA-4mSl2xSsnP_75w/senddocument HTTP/1.1[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Transfer-Encoding: chunked[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Content-Type: multipart/form-data; boundary=ivASnGeC3skSGavyMw891nfeSGsI2ui_EFV[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Host: api.telegram.org[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Connection: Keep-Alive[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "User-Agent: Apache-HttpClient/4.5.3 (Java/1.8.0_121)[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Accept-Encoding: gzip,deflate[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "b1[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "--ivASnGeC3skSGavyMw891nfeSGsI2ui_EFV[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Content-Disposition: form-data; name="chat_id"[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Content-Type: text/plain; charset=ISO-8859-1[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Content-Transfer-Encoding: 8bit[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "143155231[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "10bf[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "--ivASnGeC3skSGavyMw891nfeSGsI2ui_EFV[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Content-Disposition: form-data; name="document"; filename="??????2.doc"[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Content-Type: application/octet-stream[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "Content-Transfer-Encoding: binary[\r][\n]"
DEBUG: org.apache.http.wire.wire (73) - http-outgoing-14 >> "[\r][\n]"
```