### PR TITLE
#269 Fixed update queue polling order and added `TelegramBatchLongPollingBot`

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramBatchLongPollingBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramBatchLongPollingBot.java
@@ -1,0 +1,16 @@
+package org.telegram.telegrambots.bots;
+
+import org.telegram.telegrambots.api.objects.Update;
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class TelegramBatchLongPollingBot extends TelegramLongPollingBot {
+
+    @Override
+    public final void onUpdateReceived(Update update) {
+        onUpdatesReceived(Collections.singletonList(update));
+    }
+
+    public abstract void onUpdatesReceived(List<Update> updates);
+}


### PR DESCRIPTION
1. Replace `pollLast` with `pollFirst` to fix update queue polling order
2. Added type `TelegramBatchLongPollingBot` with `onUpdatesReceived` method that takes a list of updates instead of a single one.
3. Added hack to the `DefaultBotSession` that polls the whole queue if it sees the `TelegramBatchLongPollingBot`. The polling method is safe for multithreading.

@rubenlagus 