### PR TITLE
Use a regular expression to split command parameters

### DIFF
--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/BotCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/BotCommand.java
@@ -11,7 +11,7 @@ import org.telegram.telegrambots.bots.AbsSender;
  */
 public abstract class BotCommand {
     public final static String COMMAND_INIT_CHARACTER = "/";
-    public static final String COMMAND_PARAMETER_SEPARATOR = " ";
+    public static final String COMMAND_PARAMETER_SEPARATOR_REGEXP = "\\s+";
     private final static int COMMAND_MAX_LENGTH = 32;
 
     private final String commandIdentifier;

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/CommandRegistry.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/CommandRegistry.java
@@ -97,7 +97,7 @@ public final class CommandRegistry implements ICommandRegistry {
             String text = message.getText();
             if (text.startsWith(BotCommand.COMMAND_INIT_CHARACTER)) {
                 String commandMessage = text.substring(1);
-                String[] commandSplit = commandMessage.split(BotCommand.COMMAND_PARAMETER_SEPARATOR);
+                String[] commandSplit = commandMessage.split(BotCommand.COMMAND_PARAMETER_SEPARATOR_REGEXP);
 
                 String command = removeUsernameFromCommandIfNeeded(commandSplit[0]);
 


### PR DESCRIPTION
Use a regular expression instead of a single space to split command parameters. This avoids spurious/empty parameters getting passed to the BotCommand `execute` method.