### PR TITLE
#336 Shutdown polling bot executor service on close

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -51,7 +51,7 @@ import static org.telegram.telegrambots.Constants.SOCKET_TIMEOUT;
 public abstract class DefaultAbsSender extends AbsSender {
     private static final ContentType TEXT_PLAIN_CONTENT_TYPE = ContentType.create("text/plain", StandardCharsets.UTF_8);
 
-    private final ExecutorService exe;
+    protected final ExecutorService exe;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final DefaultBotOptions options;
     private volatile CloseableHttpClient httpclient;

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
@@ -55,4 +55,10 @@ public abstract class TelegramLongPollingBot extends DefaultAbsSender implements
             throw new TelegramApiRequestException("Error executing setWebook method", e);
         }
     }
+
+    @Override
+    public void onClosing() {
+        exe.shutdown();
+    }
+
 }

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/TelegramLongPollingBotTest.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/TelegramLongPollingBotTest.java
@@ -3,11 +3,17 @@ package org.telegram.telegrambots.test;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.telegram.telegrambots.api.objects.Update;
+import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
+import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyList;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class TelegramLongPollingBotTest {
 
@@ -21,4 +27,41 @@ public class TelegramLongPollingBotTest {
         Mockito.verify(bot).onUpdateReceived(update1);
         Mockito.verify(bot).onUpdateReceived(update2);
     }
+
+    @Test
+    public void testExecutorShutdown() throws Exception {
+        TestBot bot = Mockito.spy(new TestBot());
+        DefaultBotSession session = new DefaultBotSession();
+        session.setCallback(bot);
+        session.setOptions(new DefaultBotOptions());
+        session.start();
+        session.stop();
+        Mockito.verify(bot).onClosing();
+        ExecutorService executor = bot.getExecutor();
+        assertThat("Executor was not shut down", executor.isShutdown(), is(true));
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+        assertThat("Executor could not terminate", executor.isTerminated(), is(true));
+    }
+
+    private static class TestBot extends TelegramLongPollingBot {
+
+        @Override
+        public void onUpdateReceived(Update update) {
+        }
+
+        ExecutorService getExecutor() {
+            return exe;
+        }
+
+        @Override
+        public String getBotUsername() {
+            return "";
+        }
+
+        @Override
+        public String getBotToken() {
+            return "";
+        }
+    }
+
 }


### PR DESCRIPTION
When the bot session is stopped, the polling bot's executor service should be shutdown so non-daemon threads don't prevent the application from terminating or undeploying from a container.