### PR TITLE
Adds a command (standard /help) that provides Linux man like features.

### DIFF
--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/HelpCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/HelpCommand.java
@@ -1,0 +1,117 @@
+package org.telegram.telegrambots.bots.commandbot.commands.helpCommand;
+
+import java.util.Collection;
+
+import org.telegram.telegrambots.api.methods.send.SendMessage;
+import org.telegram.telegrambots.api.objects.Chat;
+import org.telegram.telegrambots.api.objects.User;
+import org.telegram.telegrambots.bots.AbsSender;
+import org.telegram.telegrambots.bots.commandbot.TelegramLongPollingCommandBot;
+import org.telegram.telegrambots.bots.commandbot.commands.BotCommand;
+import org.telegram.telegrambots.bots.commandbot.commands.ICommandRegistry;
+import org.telegram.telegrambots.exceptions.TelegramApiException;
+
+/**
+ * A special bot command used for printing help messages similiar to the Linux man command.
+ * The commands printed by this command should implement the {@link IManCommand} interface to provide an extended description.
+ * @author Lukas Prediger(Chase)
+ * @version 1.0.0
+ *
+ */
+public class HelpCommand extends ManCommand {
+	
+	private static final String COMMAND_IDENTIFIER = "help";
+	private static final String COMMAND_DESCRIPTION = "shows all commands. Use /help [command] for more info";
+	private static final String EXTENDED_DESCRIPTION = "This command displays all commands the bot has to offer.\n /help [command] can display deeper information";
+	
+	/**
+	 * Returns the command and description of all supplied commands as a formatted String
+	 * @param botCommands the Commands that should be included in the String
+	 * @return a formatted String containing command and description for all supplied commands
+	 */
+	public static String getHelpText(BotCommand...botCommands) {
+		StringBuilder reply = new StringBuilder();
+		for (BotCommand com : botCommands) {
+			reply.append(com.toString()).append(System.lineSeparator()).append(System.lineSeparator());
+		}
+		return reply.toString();
+	}
+
+	/**
+	 * Returns the command and description of all supplied commands as a formatted String
+	 * @param botCommands a collection of commands that should be included in the String
+	 * @return a formatted String containing command and description for all supplied commands
+	 */
+	public static String getHelpText(Collection<BotCommand> botCommands) {
+		return getHelpText(botCommands.toArray(new BotCommand[botCommands.size()]));
+	}
+
+	/**
+	 * Returns the command and description of all supplied commands as a formatted String
+	 * @param registry a commandRegistry which commands are formatted into the String
+	 * @return a formatted String containing command and description for all supplied commands
+	 */
+	public static String getHelpText(ICommandRegistry registry) {
+		return getHelpText(registry.getRegisteredCommands());
+	}
+	
+	/**
+	 * Reads the extended Description from a BotCommand. If the Command is not of Type {@link IManCommand}, it returns the normal Description;
+	 * @param command a command the extended Descriptions is read from
+	 * @return the extended Description or the normal Description if IManCommand is not implemented
+	 */
+	public static String getManText(BotCommand command) {
+		return IManCommand.class.isInstance(command) ? getManText((IManCommand) command) : command.getDescription();
+	}
+	
+	/**
+	 * Reads the extended Description from a BotCommand;
+	 * @param command a command the extended Descriptions is read from
+	 * @return the extended Description
+	 */
+	public static String getManText(IManCommand command) {
+		return command.toMan();
+	}
+	
+	/**
+	 * Create a Help command with the standard Arguments.
+	 */
+	public HelpCommand() {
+		super(COMMAND_IDENTIFIER, COMMAND_DESCRIPTION, EXTENDED_DESCRIPTION);
+	}
+	
+	/**
+	 * Creates a Help Command with custom identifier, description and extended Description
+	* @param commandIdentifier the unique identifier of this command (e.g. the command string to enter into chat)
+     * @param description the description of this command
+	 * @param extendedDescription The extended Description for the Command, should provide detailed information about arguments and possible options
+	 */
+	public HelpCommand(String commandIdentifier, String description, String extendedDescription) {
+		super(commandIdentifier, description, extendedDescription);
+	}
+	
+	@Override
+	public void execute(AbsSender absSender, User user, Chat chat, String[] arguments) {
+		if (ICommandRegistry.class.isInstance(absSender)) {
+			ICommandRegistry registry = (ICommandRegistry) absSender;
+			
+			if (arguments.length > 0) {
+				BotCommand command = registry.getRegisteredCommand(arguments[0]);
+				String reply = getManText(command);
+				try {
+					absSender.execute(new SendMessage(chat.getId(), reply).setParseMode("HTML"));
+				} catch (TelegramApiException e) {
+					e.printStackTrace();
+				}
+			} else {
+				String reply = getHelpText(registry);
+				try {
+					absSender.execute(new SendMessage(chat.getId(), reply).setParseMode("HTML"));
+				} catch (TelegramApiException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/HelpCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/HelpCommand.java
@@ -56,12 +56,12 @@ public class HelpCommand extends ManCommand {
 	}
 	
 	/**
-	 * Reads the extended Description from a BotCommand. If the Command is not of Type {@link IManCommand}, it returns the normal Description;
+	 * Reads the extended Description from a BotCommand. If the Command is not of Type {@link IManCommand}, it calls toString();
 	 * @param command a command the extended Descriptions is read from
-	 * @return the extended Description or the normal Description if IManCommand is not implemented
+	 * @return the extended Description or the toString() if IManCommand is not implemented
 	 */
 	public static String getManText(BotCommand command) {
-		return IManCommand.class.isInstance(command) ? getManText((IManCommand) command) : command.getDescription();
+		return IManCommand.class.isInstance(command) ? getManText((IManCommand) command) : command.toString();
 	}
 	
 	/**

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/IManCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/IManCommand.java
@@ -1,0 +1,21 @@
+package org.telegram.telegrambots.bots.commandbot.commands.helpCommand;
+
+/**
+ * Represents a Command that, aside the normal command description provides an extended Description similar to the output of the Linux <i>man</i> command
+ * @author Lukas Prediger(Chase)
+ * @version 1.0.0
+ */
+public interface IManCommand {
+	/**
+	 * Returns the extended Description of this command
+	 * @return the extendedDescription
+	 */
+	String getExtendedDescription();
+	
+	/**
+	 * Returns a String Representations of the Command and it's extended Description.
+	 * @return a String representing the Command and it's extended Description
+	 */
+	String toMan();
+
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/ManCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/ManCommand.java
@@ -1,0 +1,41 @@
+package org.telegram.telegrambots.bots.commandbot.commands.helpCommand;
+
+import org.telegram.telegrambots.bots.commandbot.commands.BotCommand;
+
+public abstract class ManCommand extends BotCommand implements IManCommand {
+	
+	private final String extendedDescription;
+	
+	/**
+	 * Create a new ManCommand providing a commandIdentifier, a short description and the extended description
+	 * @param commandIdentifier the unique identifier of this command (e.g. the command string to enter into chat)
+     * @param description the description of this command
+	 * @param extendedDescription The extended Description for the Command, should provide detailed information about arguments and possible options
+	 */
+	public ManCommand(String commandIdentifier, String description, String extendedDescription) {
+		super(commandIdentifier, description);
+		this.extendedDescription = extendedDescription;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.telegram.telegrambots.bots.commandbot.commands.helpCommand.IManCommand#getExtendedDescription()
+	 */
+	@Override
+	public String getExtendedDescription() {
+		return extendedDescription;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.telegram.telegrambots.bots.commandbot.commands.helpCommand.IManCommand#toMan()
+	 */
+	@Override
+	public String toMan() {
+		StringBuilder sb = new StringBuilder(toString());
+		sb.append(System.lineSeparator())
+		.append("-----------------")
+		.append(System.lineSeparator());
+		if (getExtendedDescription() != null) sb.append(getExtendedDescription());
+		return sb.toString();
+	}
+
+}


### PR DESCRIPTION
Contains 2 Classes, 1 Interface
IManCommand: adds support for an extended Description to a command
ManCommand: standard Implementation of IManCommand
HelpCommand: Command used to print help messages

Standard output of /help
```
/{Command1 identifier}
{Command1 description}

/{Command2 identifier}
{Command2 description}
```

Output of /help [command] if implements IManCommand

```
/{command identifier}
{command description}
--------------------
[command extendedDescription]
```
if doesn't implements IManCommand

```
/{command identifier}
{command description}
```
