### PR TITLE
Fixed Bot API methods

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/AnswerCallbackQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/AnswerCallbackQuery.java
@@ -97,8 +97,9 @@ public class AnswerCallbackQuery extends BotApiMethod<Boolean> {
         return cacheTime;
     }
 
-    public void setCacheTime(Integer cacheTime) {
+    public AnswerCallbackQuery setCacheTime(Integer cacheTime) {
         this.cacheTime = cacheTime;
+        return this;
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/StopMessageLiveLocation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/StopMessageLiveLocation.java
@@ -60,7 +60,6 @@ public class StopMessageLiveLocation extends BotApiMethod<Serializable> {
     }
 
     public StopMessageLiveLocation setChatId(Long chatId) {
-        Objects.requireNonNull(chatId);
         this.chatId = chatId.toString();
         return this;
     }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/games/GetGameHighScores.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/games/GetGameHighScores.java
@@ -86,7 +86,6 @@ public class GetGameHighScores extends BotApiMethod<ArrayList<GameHighScore>> {
     }
 
     public GetGameHighScores setChatId(Long chatId) {
-        Objects.requireNonNull(chatId);
         this.chatId = chatId.toString();
         return this;
     }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/games/SetGameScore.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/games/SetGameScore.java
@@ -104,7 +104,6 @@ public class SetGameScore extends BotApiMethod<Serializable> {
     }
 
     public SetGameScore setChatId(Long chatId) {
-        Objects.requireNonNull(chatId);
         this.chatId = chatId.toString();
         return this;
     }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/updatingmessages/EditMessageLiveLocation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/updatingmessages/EditMessageLiveLocation.java
@@ -104,7 +104,7 @@ public class EditMessageLiveLocation extends BotApiMethod<Serializable> {
     }
 
     public EditMessageLiveLocation setLatitude(Float latitude) {
-        Objects.requireNonNull(chatId);
+        Objects.requireNonNull(latitude);
         this.latitude = latitude;
         return this;
     }
@@ -114,7 +114,7 @@ public class EditMessageLiveLocation extends BotApiMethod<Serializable> {
     }
 
     public EditMessageLiveLocation setLongitud(Float longitud) {
-        Objects.requireNonNull(chatId);
+        Objects.requireNonNull(longitud);
         this.longitud = longitud;
         return this;
     }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/updatingmessages/EditMessageReplyMarkup.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/updatingmessages/EditMessageReplyMarkup.java
@@ -63,7 +63,6 @@ public class EditMessageReplyMarkup extends BotApiMethod<Serializable> {
     }
 
     public EditMessageReplyMarkup setChatId(Long chatId) {
-        Objects.requireNonNull(chatId);
         this.chatId = chatId.toString();
         return this;
     }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/updatingmessages/EditMessageText.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/api/methods/updatingmessages/EditMessageText.java
@@ -79,7 +79,6 @@ public class EditMessageText extends BotApiMethod<Serializable> {
     }
 
     public EditMessageText setChatId(Long chatId) {
-        Objects.requireNonNull(chatId);
         this.chatId = chatId.toString();
         return this;
     }


### PR DESCRIPTION
## AnswerCallbackQuery
`setCacheTime(...)`  now returns `AnswerCallbackQuery`

## EditMessageLiveLocation
`setLongitud(...)`  corrected requireNonNull check
`setLatitude(...)`  corrected requireNonNull check

## Suggestion
Removed `Objects.requireNonNull(chatId)` check from methods which can have `inline_message_id` instead of `chat_id`