### PR TITLE
Add IBotCommand to create Commands that get whole Message

### DIFF
--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/TelegramLongPollingCommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/TelegramLongPollingCommandBot.java
@@ -9,6 +9,7 @@ import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
 import org.telegram.telegrambots.bots.commandbot.commands.BotCommand;
 import org.telegram.telegrambots.bots.commandbot.commands.CommandRegistry;
+import org.telegram.telegrambots.bots.commandbot.commands.IBotCommand;
 import org.telegram.telegrambots.bots.commandbot.commands.ICommandRegistry;
 
 import java.util.Collection;
@@ -105,27 +106,27 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
     }
 
     @Override
-    public final boolean register(BotCommand botCommand) {
+    public final boolean register(IBotCommand botCommand) {
         return commandRegistry.register(botCommand);
     }
 
     @Override
-    public final Map<BotCommand, Boolean> registerAll(BotCommand... botCommands) {
+    public final Map<IBotCommand, Boolean> registerAll(IBotCommand... botCommands) {
         return commandRegistry.registerAll(botCommands);
     }
 
     @Override
-    public final boolean deregister(BotCommand botCommand) {
+    public final boolean deregister(IBotCommand botCommand) {
         return commandRegistry.deregister(botCommand);
     }
 
     @Override
-    public final Map<BotCommand, Boolean> deregisterAll(BotCommand... botCommands) {
+    public final Map<IBotCommand, Boolean> deregisterAll(IBotCommand... botCommands) {
         return commandRegistry.deregisterAll(botCommands);
     }
 
     @Override
-    public final Collection<BotCommand> getRegisteredCommands() {
+    public final Collection<IBotCommand> getRegisteredCommands() {
         return commandRegistry.getRegisteredCommands();
     }
 
@@ -135,7 +136,7 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
     }
 
     @Override
-    public final BotCommand getRegisteredCommand(String commandIdentifier) {
+    public final IBotCommand getRegisteredCommand(String commandIdentifier) {
         return commandRegistry.getRegisteredCommand(commandIdentifier);
     }
 

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/BotCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/BotCommand.java
@@ -10,7 +10,7 @@ import org.telegram.telegrambots.bots.AbsSender;
  *
  * @author Timo Schulz (Mit0x2)
  */
-public abstract class BotCommand {
+public abstract class BotCommand implements IBotCommand {
     public final static String COMMAND_INIT_CHARACTER = "/";
     public static final String COMMAND_PARAMETER_SEPARATOR_REGEXP = "\\s+";
     private final static int COMMAND_MAX_LENGTH = 32;
@@ -74,7 +74,7 @@ public abstract class BotCommand {
      * @param message   the message to process
      * @param arguments passed arguments
      */
-    void processMessage(AbsSender absSender, Message message, String[] arguments) {
+    public void processMessage(AbsSender absSender, Message message, String[] arguments) {
         execute(absSender, message.getFrom(), message.getChat(), arguments);
     }
 

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/CommandRegistry.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/CommandRegistry.java
@@ -16,7 +16,7 @@ import java.util.function.BiConsumer;
  */
 public final class CommandRegistry implements ICommandRegistry {
 
-    private final Map<String, BotCommand> commandRegistryMap = new HashMap<>();
+    private final Map<String, IBotCommand> commandRegistryMap = new HashMap<>();
     private final boolean allowCommandsWithUsername;
     private final String botUsername;
     private BiConsumer<AbsSender, Message> defaultConsumer;
@@ -37,7 +37,7 @@ public final class CommandRegistry implements ICommandRegistry {
     }
 
     @Override
-    public final boolean register(BotCommand botCommand) {
+    public final boolean register(IBotCommand botCommand) {
         if (commandRegistryMap.containsKey(botCommand.getCommandIdentifier())) {
             return false;
         }
@@ -46,16 +46,16 @@ public final class CommandRegistry implements ICommandRegistry {
     }
 
     @Override
-    public final Map<BotCommand, Boolean> registerAll(BotCommand... botCommands) {
-        Map<BotCommand, Boolean> resultMap = new HashMap<>(botCommands.length);
-        for (BotCommand botCommand : botCommands) {
+    public final Map<IBotCommand, Boolean> registerAll(IBotCommand... botCommands) {
+        Map<IBotCommand, Boolean> resultMap = new HashMap<>(botCommands.length);
+        for (IBotCommand botCommand : botCommands) {
             resultMap.put(botCommand, register(botCommand));
         }
         return resultMap;
     }
 
     @Override
-    public final boolean deregister(BotCommand botCommand) {
+    public final boolean deregister(IBotCommand botCommand) {
         if (commandRegistryMap.containsKey(botCommand.getCommandIdentifier())) {
             commandRegistryMap.remove(botCommand.getCommandIdentifier());
             return true;
@@ -64,21 +64,21 @@ public final class CommandRegistry implements ICommandRegistry {
     }
 
     @Override
-    public final Map<BotCommand, Boolean> deregisterAll(BotCommand... botCommands) {
-        Map<BotCommand, Boolean> resultMap = new HashMap<>(botCommands.length);
-        for (BotCommand botCommand : botCommands) {
+    public final Map<IBotCommand, Boolean> deregisterAll(IBotCommand... botCommands) {
+        Map<IBotCommand, Boolean> resultMap = new HashMap<>(botCommands.length);
+        for (IBotCommand botCommand : botCommands) {
             resultMap.put(botCommand, deregister(botCommand));
         }
         return resultMap;
     }
 
     @Override
-    public final Collection<BotCommand> getRegisteredCommands() {
+    public final Collection<IBotCommand> getRegisteredCommands() {
         return commandRegistryMap.values();
     }
 
     @Override
-    public final BotCommand getRegisteredCommand(String commandIdentifier) {
+    public final IBotCommand getRegisteredCommand(String commandIdentifier) {
         return commandRegistryMap.get(commandIdentifier);
     }
 

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/DefaultBotCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/DefaultBotCommand.java
@@ -31,7 +31,7 @@ public abstract class DefaultBotCommand extends BotCommand {
      * @param arguments passed arguments
      */
     @Override
-    void processMessage(AbsSender absSender, Message message, String[] arguments) {
+    public void processMessage(AbsSender absSender, Message message, String[] arguments) {
         execute(absSender, message.getFrom(), message.getChat(), message.getMessageId(), arguments);
     }
 

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/IBotCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/IBotCommand.java
@@ -1,0 +1,37 @@
+package org.telegram.telegrambots.bots.commandbot.commands;
+
+import org.telegram.telegrambots.api.objects.Message;
+import org.telegram.telegrambots.bots.AbsSender;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * This Interface represents the a Command that can be executed
+ *
+ * @author Timo Schulz (Mit0x2)
+ */
+public interface IBotCommand {
+    /**
+     * Get the identifier of this command
+     *
+     * @return the identifier
+     */
+    String getCommandIdentifier();
+
+    /**
+     * Get the description of this command
+     *
+     * @return the description as String
+     */
+    String getDescription();
+
+    /**
+     * Process the message and execute the command
+     *
+     * @param absSender absSender to send messages over
+     * @param message   the message to process
+     */
+    void processMessage(AbsSender absSender, Message message, String[] arguments);
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/ICommandRegistry.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/ICommandRegistry.java
@@ -29,7 +29,7 @@ public interface ICommandRegistry {
      * @param botCommand the command to register
      * @return whether the command could be registered, was not already registered
      */
-    boolean register(BotCommand botCommand);
+    boolean register(IBotCommand botCommand);
 
     /**
      * register multiple commands
@@ -37,7 +37,7 @@ public interface ICommandRegistry {
      * @param botCommands commands to register
      * @return map with results of the command register per command
      */
-    Map<BotCommand, Boolean> registerAll(BotCommand... botCommands);
+    Map<IBotCommand, Boolean> registerAll(IBotCommand... botCommands);
 
     /**
      * deregister a command
@@ -45,7 +45,7 @@ public interface ICommandRegistry {
      * @param botCommand the command to deregister
      * @return whether the command could be deregistered, was registered
      */
-    boolean deregister(BotCommand botCommand);
+    boolean deregister(IBotCommand botCommand);
 
     /**
      * deregister multiple commands
@@ -53,19 +53,19 @@ public interface ICommandRegistry {
      * @param botCommands commands to deregister
      * @return map with results of the command deregistered per command
      */
-    Map<BotCommand, Boolean> deregisterAll(BotCommand... botCommands);
+    Map<IBotCommand, Boolean> deregisterAll(IBotCommand... botCommands);
 
     /**
      * get a collection of all registered commands
      *
      * @return a collection of registered commands
      */
-    Collection<BotCommand> getRegisteredCommands();
+    Collection<IBotCommand> getRegisteredCommands();
 
     /**
      * get registered command
      *
      * @return registered command if exists or null if not
      */
-    BotCommand getRegisteredCommand(String commandIdentifier);
+    IBotCommand getRegisteredCommand(String commandIdentifier);
 }

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/HelpCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/bots/commandbot/commands/helpCommand/HelpCommand.java
@@ -1,15 +1,14 @@
 package org.telegram.telegrambots.bots.commandbot.commands.helpCommand;
 
-import java.util.Collection;
-
 import org.telegram.telegrambots.api.methods.send.SendMessage;
 import org.telegram.telegrambots.api.objects.Chat;
 import org.telegram.telegrambots.api.objects.User;
 import org.telegram.telegrambots.bots.AbsSender;
-import org.telegram.telegrambots.bots.commandbot.TelegramLongPollingCommandBot;
-import org.telegram.telegrambots.bots.commandbot.commands.BotCommand;
+import org.telegram.telegrambots.bots.commandbot.commands.IBotCommand;
 import org.telegram.telegrambots.bots.commandbot.commands.ICommandRegistry;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
+
+import java.util.Collection;
 
 /**
  * A special bot command used for printing help messages similiar to the Linux man command.
@@ -29,9 +28,9 @@ public class HelpCommand extends ManCommand {
 	 * @param botCommands the Commands that should be included in the String
 	 * @return a formatted String containing command and description for all supplied commands
 	 */
-	public static String getHelpText(BotCommand...botCommands) {
+	public static String getHelpText(IBotCommand...botCommands) {
 		StringBuilder reply = new StringBuilder();
-		for (BotCommand com : botCommands) {
+		for (IBotCommand com : botCommands) {
 			reply.append(com.toString()).append(System.lineSeparator()).append(System.lineSeparator());
 		}
 		return reply.toString();
@@ -42,8 +41,8 @@ public class HelpCommand extends ManCommand {
 	 * @param botCommands a collection of commands that should be included in the String
 	 * @return a formatted String containing command and description for all supplied commands
 	 */
-	public static String getHelpText(Collection<BotCommand> botCommands) {
-		return getHelpText(botCommands.toArray(new BotCommand[botCommands.size()]));
+	public static String getHelpText(Collection<IBotCommand> botCommands) {
+		return getHelpText(botCommands.toArray(new IBotCommand[botCommands.size()]));
 	}
 
 	/**
@@ -60,7 +59,7 @@ public class HelpCommand extends ManCommand {
 	 * @param command a command the extended Descriptions is read from
 	 * @return the extended Description or the toString() if IManCommand is not implemented
 	 */
-	public static String getManText(BotCommand command) {
+	public static String getManText(IBotCommand command) {
 		return IManCommand.class.isInstance(command) ? getManText((IManCommand) command) : command.toString();
 	}
 	
@@ -96,7 +95,7 @@ public class HelpCommand extends ManCommand {
 			ICommandRegistry registry = (ICommandRegistry) absSender;
 			
 			if (arguments.length > 0) {
-				BotCommand command = registry.getRegisteredCommand(arguments[0]);
+				IBotCommand command = registry.getRegisteredCommand(arguments[0]);
 				String reply = getManText(command);
 				try {
 					absSender.execute(new SendMessage(chat.getId(), reply).setParseMode("HTML"));


### PR DESCRIPTION
## Problem

I need to create a command that gets the original content as a string, not only the arguments array, because I need the lines.

## Solution

I tried to keep it as close to the original design as possible, keeping it backwards compatible. 

My solution is to create an IBotCommand interface that has the method

```
    void processMessage(AbsSender absSender, Message message, String[] arguments);
```

By doing this the bot is more extensible by allowing end users to implement this interface, or like it was already possible, just extend the BotCommand.