### PR TITLE
implemented authorization via http proxy

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
@@ -1,5 +1,7 @@
 package org.telegram.telegrambots.bots;
 
+import org.apache.http.HttpHost;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.telegram.telegrambots.ApiConstants;
 import org.telegram.telegrambots.generics.BotOptions;
@@ -20,6 +22,9 @@ public class DefaultBotOptions implements BotOptions {
     private Integer maxWebhookConnections;
     private String baseUrl;
     private List<String> allowedUpdates;
+
+    private CredentialsProvider credentialsProvider;
+    private HttpHost httpProxy;
 
     public DefaultBotOptions() {
         maxThreads = 1;
@@ -81,5 +86,21 @@ public class DefaultBotOptions implements BotOptions {
      */
     public void setExponentialBackOff(ExponentialBackOff exponentialBackOff) {
         this.exponentialBackOff = exponentialBackOff;
+    }
+
+    public CredentialsProvider getCredentialsProvider() {
+        return credentialsProvider;
+    }
+
+    public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
+        this.credentialsProvider = credentialsProvider;
+    }
+
+    public HttpHost getHttpProxy() {
+        return httpProxy;
+    }
+
+    public void setHttpProxy(HttpHost httpProxy) {
+        this.httpProxy = httpProxy;
     }
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
@@ -36,7 +36,7 @@ public abstract class TelegramLongPollingBot extends DefaultAbsSender implements
 
     @Override
     public void clearWebhook() throws TelegramApiRequestException {
-        try (CloseableHttpClient httpclient = HttpClientBuilder.create().setSSLHostnameVerifier(new NoopHostnameVerifier()).build()) {
+        try (CloseableHttpClient httpclient = this.createHttpClient()) {
             String url = getOptions().getBaseUrl() + getBotToken() + "/" + SetWebhook.PATH;
             HttpGet httpGet = new HttpGet(url);
             httpGet.setConfig(getOptions().getRequestConfig());

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramWebhookBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramWebhookBot.java
@@ -44,7 +44,7 @@ public abstract class TelegramWebhookBot extends DefaultAbsSender implements Web
 
     @Override
     public void setWebhook(String url, String publicCertificatePath) throws TelegramApiRequestException {
-        try (CloseableHttpClient httpclient = HttpClientBuilder.create().setSSLHostnameVerifier(new NoopHostnameVerifier()).build()) {
+        try (CloseableHttpClient httpclient = this.createHttpClient()) {
             String requestUrl = getBaseUrl() + SetWebhook.PATH;
 
             HttpPost httppost = new HttpPost(requestUrl);


### PR DESCRIPTION
The initialization will be like
```java
try {

            // Create the TelegramBotsApi object to register your bots
            TelegramBotsApi botsApi = new TelegramBotsApi();

            DefaultBotOptions botOptions = ApiContext.getInstance(DefaultBotOptions.class);
            if (NEED_AUTHORIZATION) {
                CredentialsProvider credsProvider = new BasicCredentialsProvider();
                credsProvider.setCredentials(
                        new AuthScope(PROXY_HOST, PROXY_PORT),
                        new UsernamePasswordCredentials(PROXY_USER, PROXY_USER_PASS));

                HttpHost httpHost = new HttpHost(PROXY_HOST, PROXY_PORT);

                RequestConfig requestConfig = RequestConfig.custom().setProxy(httpHost).setAuthenticationEnabled(true).build();
                botOptions.setRequestConfig(requestConfig);
                botOptions.setCredentialsProvider(credsProvider);
                botOptions.setHttpProxy(httpHost);
            }

            // Register your newly created AbilityBot
            TelegramBot bot = new TelegramBot(appContext, botOptions);
            //bot.setContext(appContext);
            BotSession session = botsApi.registerBot(bot);

            //session.setOptions(botOptions);
        } catch (TelegramApiException e) {
            e.printStackTrace();
        }
```