### PR TITLE
Dev: Implemented http proxy authorization

### DIFF
--- a/TelegramBots.wiki/Using-Http-Proxy.md
+++ b/TelegramBots.wiki/Using-Http-Proxy.md
@@ -1,0 +1,122 @@
+### Using HTTP proxy
+
+HTTP proxy support implemented since version 3.6.1
+
+First of all you need to override constructor with `DefaultBotOptions` argument while inheriting from `AbilityBot` or `TelegramLongPollingBot`
+
+```java
+public class MyBot extends AbilityBot {
+
+    protected MyBot(String botToken, String botUsername, DefaultBotOptions botOptions) {
+        super(botToken, botUsername, botOptions);
+    }
+
+    public int creatorId() {
+        return 0;
+    }
+
+    public Ability pingPong() {
+        return Ability
+                .builder()
+                .name("ping")
+                .info("ping pong")
+                .locality(ALL)
+                .privacy(PUBLIC)
+                .action(ctx -> silent.send("pong", ctx.chatId()))
+                .build();
+    }
+
+}
+```
+
+Now you are able to set up your proxy
+
+#### without authentication
+
+```java
+public class Main {
+
+    private static String BOT_NAME = "My test bot";
+    private static String BOT_TOKEN = "..." /* your bot's token here */;
+
+    private static String PROXY_HOST = "..." /* proxy host */;
+    private static Integer PROXY_PORT = 3128 /* proxy port */;
+
+    public static void main(String[] args) {
+        try {
+
+            ApiContextInitializer.init();
+
+            // Create the TelegramBotsApi object to register your bots
+            TelegramBotsApi botsApi = new TelegramBotsApi();
+
+            // Set up Http proxy
+            DefaultBotOptions botOptions = ApiContext.getInstance(DefaultBotOptions.class);
+
+            HttpHost httpHost = new HttpHost(PROXY_HOST, PROXY_PORT);
+
+            RequestConfig requestConfig = RequestConfig.custom().setProxy(httpHost).setAuthenticationEnabled(false).build();
+            botOptions.setRequestConfig(requestConfig);
+            botOptions.setHttpProxy(httpHost);
+
+            // Register your newly created AbilityBot
+            MyBot bot = new MyBot(BOT_TOKEN, BOT_NAME, botOptions);
+
+            botsApi.registerBot(bot);
+
+        } catch (TelegramApiException e) {
+            e.printStackTrace();
+        }
+    }
+}
+
+```
+
+
+#### With authentication
+
+```java
+public class Main {
+
+    private static String BOT_NAME = "My test bot";
+    private static String BOT_TOKEN = "..." /* your bot's token here */;
+
+    private static String PROXY_HOST = "..." /* proxy host */;
+    private static Integer PROXY_PORT = 3128 /* proxy port */;
+    private static String PROXY_USER = "..." /* proxy user */;
+    private static String PROXY_PASSWORD = "..." /* proxy password */;
+
+    public static void main(String[] args) {
+        try {
+
+            ApiContextInitializer.init();
+
+            // Create the TelegramBotsApi object to register your bots
+            TelegramBotsApi botsApi = new TelegramBotsApi();
+
+            // Set up Http proxy
+            DefaultBotOptions botOptions = ApiContext.getInstance(DefaultBotOptions.class);
+
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(
+                    new AuthScope(PROXY_HOST, PROXY_PORT),
+                    new UsernamePasswordCredentials(PROXY_USER, PROXY_PASSWORD));
+
+            HttpHost httpHost = new HttpHost(PROXY_HOST, PROXY_PORT);
+
+            RequestConfig requestConfig = RequestConfig.custom().setProxy(httpHost).setAuthenticationEnabled(true).build();
+            botOptions.setRequestConfig(requestConfig);
+            botOptions.setCredentialsProvider(credsProvider);
+            botOptions.setHttpProxy(httpHost);
+
+            // Register your newly created AbilityBot
+            MyBot bot = new MyBot(BOT_TOKEN, BOT_NAME, botOptions);
+
+            botsApi.registerBot(bot);
+
+        } catch (TelegramApiException e) {
+            e.printStackTrace();
+        }
+    }
+}
+```

--- a/TelegramBots.wiki/_Sidebar.md
+++ b/TelegramBots.wiki/_Sidebar.md
@@ -1,6 +1,7 @@
 * Users guide
     * [[Getting Started]]
     * [[Errors Handling]]
+    * [[Using HTTP Proxy]]
     * [[FAQ]]
 * AbilityBot
     * [[Simple Example]]

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -13,6 +13,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.ProxyAuthenticationStrategy;
 import org.apache.http.util.EntityUtils;
 import org.telegram.telegrambots.api.methods.BotApiMethod;
 import org.telegram.telegrambots.api.methods.groupadministration.SetChatPhoto;
@@ -61,11 +62,23 @@ public abstract class DefaultAbsSender extends AbsSender {
         super();
         this.exe = Executors.newFixedThreadPool(options.getMaxThreads());
         this.options = options;
-        httpclient = HttpClientBuilder.create()
-                .setSSLHostnameVerifier(new NoopHostnameVerifier())
-                .setConnectionTimeToLive(70, TimeUnit.SECONDS)
-                .setMaxConnTotal(100)
-                .build();
+
+        if (options.getCredentialsProvider() != null) {
+            httpclient = HttpClientBuilder.create()
+                    .setProxy(options.getHttpProxy())
+                    .setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy())
+                    .setDefaultCredentialsProvider(options.getCredentialsProvider())
+                    .setSSLHostnameVerifier(new NoopHostnameVerifier())
+                    .setConnectionTimeToLive(70, TimeUnit.SECONDS)
+                    .setMaxConnTotal(100)
+                    .build();
+        } else {
+            httpclient = HttpClientBuilder.create()
+                    .setSSLHostnameVerifier(new NoopHostnameVerifier())
+                    .setConnectionTimeToLive(70, TimeUnit.SECONDS)
+                    .setMaxConnTotal(100)
+                    .build();
+        }
 
         requestConfig = options.getRequestConfig();
 
@@ -85,6 +98,29 @@ public abstract class DefaultAbsSender extends AbsSender {
 
     public final DefaultBotOptions getOptions() {
         return options;
+    }
+
+    protected CloseableHttpClient createHttpClient() {
+        CloseableHttpClient localClient = null;
+
+        if (options.getCredentialsProvider() != null) {
+            localClient = HttpClientBuilder.create()
+                    .setProxy(options.getHttpProxy())
+                    .setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy())
+                    .setDefaultCredentialsProvider(options.getCredentialsProvider())
+                    .setSSLHostnameVerifier(new NoopHostnameVerifier())
+                    .setConnectionTimeToLive(70, TimeUnit.SECONDS)
+                    .setMaxConnTotal(100)
+                    .build();
+        } else {
+            localClient = HttpClientBuilder.create()
+                    .setSSLHostnameVerifier(new NoopHostnameVerifier())
+                    .setConnectionTimeToLive(70, TimeUnit.SECONDS)
+                    .setMaxConnTotal(100)
+                    .build();
+        }
+
+        return localClient;
     }
 
     // Send Requests

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -27,6 +27,7 @@ import org.telegram.telegrambots.api.objects.media.InputMedia;
 import org.telegram.telegrambots.exceptions.TelegramApiException;
 import org.telegram.telegrambots.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.exceptions.TelegramApiValidationException;
+import org.telegram.telegrambots.facilities.TelegramHttpClientBuilder;
 import org.telegram.telegrambots.updateshandlers.DownloadFileCallback;
 import org.telegram.telegrambots.updateshandlers.SentCallback;
 
@@ -63,7 +64,7 @@ public abstract class DefaultAbsSender extends AbsSender {
         this.exe = Executors.newFixedThreadPool(options.getMaxThreads());
         this.options = options;
 
-        httpclient = createHttpClient();
+        httpclient = TelegramHttpClientBuilder.build(options);
 
         requestConfig = options.getRequestConfig();
 
@@ -83,29 +84,6 @@ public abstract class DefaultAbsSender extends AbsSender {
 
     public final DefaultBotOptions getOptions() {
         return options;
-    }
-
-    protected CloseableHttpClient createHttpClient() {
-        CloseableHttpClient localClient = null;
-
-        if (options.getCredentialsProvider() != null) {
-            localClient = HttpClientBuilder.create()
-                    .setProxy(options.getHttpProxy())
-                    .setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy())
-                    .setDefaultCredentialsProvider(options.getCredentialsProvider())
-                    .setSSLHostnameVerifier(new NoopHostnameVerifier())
-                    .setConnectionTimeToLive(70, TimeUnit.SECONDS)
-                    .setMaxConnTotal(100)
-                    .build();
-        } else {
-            localClient = HttpClientBuilder.create()
-                    .setSSLHostnameVerifier(new NoopHostnameVerifier())
-                    .setConnectionTimeToLive(70, TimeUnit.SECONDS)
-                    .setMaxConnTotal(100)
-                    .build();
-        }
-
-        return localClient;
     }
 
     // Send Requests

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -63,22 +63,7 @@ public abstract class DefaultAbsSender extends AbsSender {
         this.exe = Executors.newFixedThreadPool(options.getMaxThreads());
         this.options = options;
 
-        if (options.getCredentialsProvider() != null) {
-            httpclient = HttpClientBuilder.create()
-                    .setProxy(options.getHttpProxy())
-                    .setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy())
-                    .setDefaultCredentialsProvider(options.getCredentialsProvider())
-                    .setSSLHostnameVerifier(new NoopHostnameVerifier())
-                    .setConnectionTimeToLive(70, TimeUnit.SECONDS)
-                    .setMaxConnTotal(100)
-                    .build();
-        } else {
-            httpclient = HttpClientBuilder.create()
-                    .setSSLHostnameVerifier(new NoopHostnameVerifier())
-                    .setConnectionTimeToLive(70, TimeUnit.SECONDS)
-                    .setMaxConnTotal(100)
-                    .build();
-        }
+        httpclient = createHttpClient();
 
         requestConfig = options.getRequestConfig();
 

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
@@ -1,5 +1,7 @@
 package org.telegram.telegrambots.bots;
 
+import org.apache.http.HttpHost;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.telegram.telegrambots.ApiConstants;
 import org.telegram.telegrambots.generics.BotOptions;
@@ -20,6 +22,9 @@ public class DefaultBotOptions implements BotOptions {
     private Integer maxWebhookConnections;
     private String baseUrl;
     private List<String> allowedUpdates;
+
+    private CredentialsProvider credentialsProvider;
+    private HttpHost httpProxy;
 
     public DefaultBotOptions() {
         maxThreads = 1;
@@ -81,5 +86,21 @@ public class DefaultBotOptions implements BotOptions {
      */
     public void setExponentialBackOff(ExponentialBackOff exponentialBackOff) {
         this.exponentialBackOff = exponentialBackOff;
+    }
+
+    public CredentialsProvider getCredentialsProvider() {
+        return credentialsProvider;
+    }
+
+    public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
+        this.credentialsProvider = credentialsProvider;
+    }
+
+    public HttpHost getHttpProxy() {
+        return httpProxy;
+    }
+
+    public void setHttpProxy(HttpHost httpProxy) {
+        this.httpProxy = httpProxy;
     }
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
@@ -36,7 +36,7 @@ public abstract class TelegramLongPollingBot extends DefaultAbsSender implements
 
     @Override
     public void clearWebhook() throws TelegramApiRequestException {
-        try (CloseableHttpClient httpclient = HttpClientBuilder.create().setSSLHostnameVerifier(new NoopHostnameVerifier()).build()) {
+        try (CloseableHttpClient httpclient = this.createHttpClient()) {
             String url = getOptions().getBaseUrl() + getBotToken() + "/" + SetWebhook.PATH;
             HttpGet httpGet = new HttpGet(url);
             httpGet.setConfig(getOptions().getRequestConfig());

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramLongPollingBot.java
@@ -14,6 +14,7 @@ import org.telegram.telegrambots.ApiConstants;
 import org.telegram.telegrambots.ApiContext;
 import org.telegram.telegrambots.api.methods.updates.SetWebhook;
 import org.telegram.telegrambots.exceptions.TelegramApiRequestException;
+import org.telegram.telegrambots.facilities.TelegramHttpClientBuilder;
 import org.telegram.telegrambots.generics.LongPollingBot;
 
 import java.io.IOException;
@@ -36,7 +37,7 @@ public abstract class TelegramLongPollingBot extends DefaultAbsSender implements
 
     @Override
     public void clearWebhook() throws TelegramApiRequestException {
-        try (CloseableHttpClient httpclient = this.createHttpClient()) {
+        try (CloseableHttpClient httpclient = TelegramHttpClientBuilder.build(getOptions())) {
             String url = getOptions().getBaseUrl() + getBotToken() + "/" + SetWebhook.PATH;
             HttpGet httpGet = new HttpGet(url);
             httpGet.setConfig(getOptions().getRequestConfig());

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramWebhookBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramWebhookBot.java
@@ -17,6 +17,7 @@ import org.telegram.telegrambots.ApiConstants;
 import org.telegram.telegrambots.ApiContext;
 import org.telegram.telegrambots.api.methods.updates.SetWebhook;
 import org.telegram.telegrambots.exceptions.TelegramApiRequestException;
+import org.telegram.telegrambots.facilities.TelegramHttpClientBuilder;
 import org.telegram.telegrambots.generics.WebhookBot;
 
 import java.io.File;
@@ -44,7 +45,7 @@ public abstract class TelegramWebhookBot extends DefaultAbsSender implements Web
 
     @Override
     public void setWebhook(String url, String publicCertificatePath) throws TelegramApiRequestException {
-        try (CloseableHttpClient httpclient = this.createHttpClient()) {
+        try (CloseableHttpClient httpclient = TelegramHttpClientBuilder.build(getOptions())) {
             String requestUrl = getBaseUrl() + SetWebhook.PATH;
 
             HttpPost httppost = new HttpPost(requestUrl);

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramWebhookBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramWebhookBot.java
@@ -44,7 +44,7 @@ public abstract class TelegramWebhookBot extends DefaultAbsSender implements Web
 
     @Override
     public void setWebhook(String url, String publicCertificatePath) throws TelegramApiRequestException {
-        try (CloseableHttpClient httpclient = HttpClientBuilder.create().setSSLHostnameVerifier(new NoopHostnameVerifier()).build()) {
+        try (CloseableHttpClient httpclient = this.createHttpClient()) {
             String requestUrl = getBaseUrl() + SetWebhook.PATH;
 
             HttpPost httppost = new HttpPost(requestUrl);

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/TelegramHttpClientBuilder.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/TelegramHttpClientBuilder.java
@@ -1,0 +1,37 @@
+package org.telegram.telegrambots.facilities;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.ProxyAuthenticationStrategy;
+import org.telegram.telegrambots.bots.DefaultBotOptions;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by bvn13 on 17.04.2018.
+ */
+public class TelegramHttpClientBuilder {
+
+    public static CloseableHttpClient build(DefaultBotOptions options) {
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
+                .setSSLHostnameVerifier(new NoopHostnameVerifier())
+                .setConnectionTimeToLive(70, TimeUnit.SECONDS)
+                .setMaxConnTotal(100);
+
+        if (options.getHttpProxy() != null) {
+
+            httpClientBuilder.setProxy(options.getHttpProxy());
+
+            if (options.getCredentialsProvider() != null) {
+                httpClientBuilder
+                        .setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy())
+                        .setDefaultCredentialsProvider(options.getCredentialsProvider());
+            }
+
+        }
+
+        return httpClientBuilder.build();
+    }
+
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
@@ -20,6 +20,7 @@ import org.telegram.telegrambots.api.methods.updates.GetUpdates;
 import org.telegram.telegrambots.api.objects.Update;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.exceptions.TelegramApiRequestException;
+import org.telegram.telegrambots.facilities.TelegramHttpClientBuilder;
 import org.telegram.telegrambots.generics.*;
 import org.telegram.telegrambots.logging.BotLogger;
 
@@ -146,32 +147,9 @@ public class DefaultBotSession implements BotSession {
             this.lock = lock;
         }
 
-        protected CloseableHttpClient createHttpClient() {
-            CloseableHttpClient localClient = null;
-
-            if (options.getCredentialsProvider() != null) {
-                localClient = HttpClientBuilder.create()
-                        .setProxy(options.getHttpProxy())
-                        .setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy())
-                        .setDefaultCredentialsProvider(options.getCredentialsProvider())
-                        .setSSLHostnameVerifier(new NoopHostnameVerifier())
-                        .setConnectionTimeToLive(70, TimeUnit.SECONDS)
-                        .setMaxConnTotal(100)
-                        .build();
-            } else {
-                localClient = HttpClientBuilder.create()
-                        .setSSLHostnameVerifier(new NoopHostnameVerifier())
-                        .setConnectionTimeToLive(70, TimeUnit.SECONDS)
-                        .setMaxConnTotal(100)
-                        .build();
-            }
-
-            return localClient;
-        }
-
         @Override
         public synchronized void start() {
-            httpclient = createHttpClient();
+            httpclient = TelegramHttpClientBuilder.build(options);
             requestConfig = options.getRequestConfig();
             exponentialBackOff = options.getExponentialBackOff();
 


### PR DESCRIPTION
Usage example:
```java
        try {
            ApiContextInitializer.init();

            // Create the TelegramBotsApi object to register your bots
            TelegramBotsApi botsApi = new TelegramBotsApi();

            DefaultBotOptions botOptions = ApiContext.getInstance(DefaultBotOptions.class);
            if (NEED_AUTHORIZATION) {
                CredentialsProvider credsProvider = new BasicCredentialsProvider();
                credsProvider.setCredentials(
                        new AuthScope(PROXY_HOST, PROXY_PORT),
                        new UsernamePasswordCredentials(PROXY_USER, PROXY_USER_PASS));

                HttpHost httpHost = new HttpHost(PROXY_HOST, PROXY_PORT);

                RequestConfig requestConfig = RequestConfig.custom().setProxy(httpHost).setAuthenticationEnabled(true).build();
                botOptions.setRequestConfig(requestConfig);
                botOptions.setCredentialsProvider(credsProvider);
                botOptions.setHttpProxy(httpHost);
            }

            // Register your newly created AbilityBot
            TelegramBot bot = new TelegramBot(TOKEN, BOT_NAME, botOptions);
            botsApi.registerBot(bot);

            //session.setOptions(botOptions);
        } catch (TelegramApiException e) {
            e.printStackTrace();
        }
```