### PR TITLE
Fix group update check for GROUP_ADMIN

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/AbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/AbilityBot.java
@@ -650,7 +650,7 @@ public abstract class AbilityBot extends TelegramLongPollingBot {
   private boolean isGroupAdmin(Update update, int id) {
     GetChatAdministrators admins = new GetChatAdministrators().setChatId(getChatId(update));
 
-    return isGroupUpdate(update) && silent.execute(admins)
+    return silent.execute(admins)
         .orElse(new ArrayList<>()).stream()
         .anyMatch(member -> member.getUser().getId() == id);
   }

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/AbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/AbilityBot.java
@@ -637,7 +637,7 @@ public abstract class AbilityBot extends TelegramLongPollingBot {
     Privacy privacy;
     int id = user.id();
 
-    privacy = isCreator(id) ? CREATOR : isAdmin(id) ? ADMIN : isGroupAdmin(update, id)? GROUP_ADMIN : PUBLIC;
+    privacy = isCreator(id) ? CREATOR : isAdmin(id) ? ADMIN : (isGroupUpdate(update) || isSuperGroupUpdate(update)) && isGroupAdmin(update, id)? GROUP_ADMIN : PUBLIC;
 
     boolean isOk = privacy.compareTo(trio.b().privacy()) >= 0;
 

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
@@ -11,7 +11,7 @@ import static java.util.Objects.nonNull;
 /**
  * Flags are an conditions that are applied on an {@link Update}.
  * <p>
- * They can be used on {@link AbilityBuilder#flag(Flag...)} and on the post conditions in {@link AbilityBuilder#reply(Consumer, Predicate[])}.
+ * They can be used on {@link AbilityBuilder#flag(Predicate[])} and on the post conditions in {@link AbilityBuilder#reply(Consumer, Predicate[])}.
  *
  * @author Abbas Abou Daya
  */

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -87,6 +87,28 @@ public final class AbilityUtils {
   }
 
   /**
+   * A "best-effort" boolean stating whether the update is a super-group message or not.
+   *
+   * @param update a Telegram {@link Update}
+   * @return whether the update is linked to a group
+   */
+  public static boolean isSuperGroupUpdate(Update update) {
+    if (MESSAGE.test(update)) {
+      return update.getMessage().isSuperGroupMessage();
+    } else if (CALLBACK_QUERY.test(update)) {
+      return update.getCallbackQuery().getMessage().isSuperGroupMessage();
+    } else if (CHANNEL_POST.test(update)) {
+      return update.getChannelPost().isSuperGroupMessage();
+    } else if (EDITED_CHANNEL_POST.test(update)) {
+      return update.getEditedChannelPost().isSuperGroupMessage();
+    } else if (EDITED_MESSAGE.test(update)) {
+      return update.getEditedMessage().isSuperGroupMessage();
+    } else {
+      return false;
+    }
+  }
+
+  /**
    * Fetches the direct chat ID of the specified update.
    *
    * @param update a Telegram {@link Update}

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
@@ -362,7 +362,7 @@ public class AbilityBotTest {
   }
 
   @Test
-  public void canValidateGroupAdminPrivacy() throws TelegramApiException {
+  public void canValidateGroupAdminPrivacy() {
     Update update = mock(Update.class);
     Message message = mock(Message.class);
     org.telegram.telegrambots.api.objects.User user = mock(User.class);
@@ -383,7 +383,7 @@ public class AbilityBotTest {
   }
 
   @Test
-  public void canRestrictNormalUsersFromGroupAdminAbilities() throws TelegramApiException {
+  public void canRestrictNormalUsersFromGroupAdminAbilities() {
     Update update = mock(Update.class);
     Message message = mock(Message.class);
     org.telegram.telegrambots.api.objects.User user = mock(User.class);


### PR DESCRIPTION
GetChatAdministrators only returns admins when there IS a group, there's no need to explicitly check for groups here.