### PR TITLE
Update library version for gradle to 4.0

### DIFF
--- a/TelegramBots.wiki/Getting-Started.md
+++ b/TelegramBots.wiki/Getting-Started.md
@@ -17,7 +17,7 @@ First you need ot get the library and add it to your project. There are few poss
     * With **Gradle**:
     
         ```groovy
-          compile group: 'org.telegram', name: 'telegrambots', version: '3.5'
+          compile group: 'org.telegram', name: 'telegrambots', version: '4.0'
         ```
  
 2. Don't like **Maven Central Repository**? It can also be taken from [Jitpack](https://jitpack.io/#rubenlagus/TelegramBots).


### PR DESCRIPTION
Don't using gradle, so don't have tested if it's already available there
Just saw it while looking through