### PR TITLE
change deprecated URL to MonsterDeveloper's book

### DIFF
--- a/TelegramBots.wiki/Home.md
+++ b/TelegramBots.wiki/Home.md
@@ -1,3 +1,3 @@
 Welcome to the TelegramBots wiki. Use the sidebar on the right. If you're not sure what to look at, why not take a look at the [[Getting Started|Getting-Started]] guide?
 
-If you want more detailed explanations, you can also visit this [gitbook by MonsterDeveloper's](https://www.gitbook.com/book/monsterdeveloper/writing-telegram-bots-on-java/details)
+If you want more detailed explanations, you can also visit this [gitbook by MonsterDeveloper's](https://monsterdeveloper.gitbooks.io/writing-telegram-bots-on-java/content/)


### PR DESCRIPTION
The URL https://legacy.gitbook.com/book/monsterdeveloper/writing-telegram-bots-on-java/details seems to be deprecated

https://monsterdeveloper.gitbooks.io/writing-telegram-bots-on-java/content/