### PR TITLE
Allow hyphen character in switchPmParameter 

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerInlineQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerInlineQuery.java
@@ -136,8 +136,8 @@ public class AnswerInlineQuery extends BotApiMethod<Boolean> {
             if (switchPmParameter.length() > 64) {
                 throw new TelegramApiValidationException("SwitchPmParameter can't be longer than 64 chars", this);
             }
-            if (!Pattern.matches("[A-Za-z0-9_]+", switchPmParameter.trim() )) {
-                throw new TelegramApiValidationException("SwitchPmParameter only allows A-Z, a-z, 0-9 and _ characters", this);
+            if (!Pattern.matches("[A-Za-z0-9_\\-]+", switchPmParameter.trim() )) {
+                throw new TelegramApiValidationException("SwitchPmParameter only allows A-Z, a-z, 0-9, _ and - characters", this);
             }
         }
         for (InlineQueryResult result : results) {

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/apimethods/TestAnswerInlineQuery.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/apimethods/TestAnswerInlineQuery.java
@@ -113,7 +113,7 @@ public class TestAnswerInlineQuery {
         try {
             answerInlineQuery.validate();
         } catch (TelegramApiValidationException e) {
-            Assert.assertEquals("SwitchPmParameter only allows A-Z, a-z, 0-9 and _ characters", e.getMessage());
+            Assert.assertEquals("SwitchPmParameter only allows A-Z, a-z, 0-9, _ and - characters", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
According to the [documentation](https://core.telegram.org/bots/api#answerinlinequery), hyphen character is allowed in `switch_pm_parameter`:

> 1-64 characters, only `A-Z`, `a-z`, `0-9`, `_` and `-` are allowed.