### PR TITLE
Update dependencies to fix CVE vulnerabilities (see #547)

### DIFF
--- a/telegrambots-abilities/pom.xml
+++ b/telegrambots-abilities/pom.xml
@@ -68,7 +68,7 @@
         <bots.version>4.1</bots.version>
         <commonslang.version>3.5</commonslang.version>
         <mapdb.version>3.0.4</mapdb.version>
-        <guava.version>19.0</guava.version>
+        <guava.version>25.1-android</guava.version>
     </properties>
 
     <dependencies>
@@ -91,6 +91,28 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-compat-qual</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/telegrambots-meta/pom.xml
+++ b/telegrambots-meta/pom.xml
@@ -59,10 +59,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <guice.version>4.1.0</guice.version>
-        <jackson.version>2.8.7</jackson.version>
-        <jacksonanotation.version>2.8.0</jacksonanotation.version>
-        <json.version>20160810</json.version>
+        <guice.version>4.2.2</guice.version>
+        <jackson.version>2.9.7</jackson.version>
+        <jacksonanotation.version>2.9.0</jacksonanotation.version>
+        <json.version>20180813</json.version>
         <junit.version>4.12</junit.version>
     </properties>
 

--- a/telegrambots/pom.xml
+++ b/telegrambots/pom.xml
@@ -62,9 +62,9 @@
         <glassfish.version>2.25.1</glassfish.version>
         <jerseybundle.version>1.19.3</jerseybundle.version>
         <httpcompontents.version>4.5.3</httpcompontents.version>
-        <json.version>20160810</json.version>
-        <jackson.version>2.8.7</jackson.version>
-        <jacksonanotation.version>2.8.0</jacksonanotation.version>
+        <json.version>20180813</json.version>
+        <jackson.version>2.9.7</jackson.version>
+        <jacksonanotation.version>2.9.0</jacksonanotation.version>
         <commonio.version>2.5</commonio.version>
         <bots.version>4.1</bots.version>
     </properties>


### PR DESCRIPTION
This PR updates the guava and jackson dependencies to fix #547 .
