### PR TITLE
Time period improvements

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/KickChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/KickChatMember.java
@@ -1,5 +1,6 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -9,6 +10,9 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -81,9 +85,23 @@ public class KickChatMember extends BotApiMethod<Boolean> {
         return untilDate;
     }
 
-    public KickChatMember setUntilDate(Integer untilDate) {
-        this.untilDate = untilDate;
+    public KickChatMember setUntilDate(Integer untilDateInSeconds) {
+        this.untilDate = untilDateInSeconds;
         return this;
+    }
+
+    @JsonIgnore
+    public KickChatMember setUntilDate(Instant instant) {
+        return setUntilDate((int) instant.getEpochSecond());
+    }
+
+    @JsonIgnore
+    public KickChatMember setUntilDate(ZonedDateTime date) {
+        return setUntilDate(date.toInstant());
+    }
+
+    public KickChatMember forTimePeriod(Duration duration) {
+        return setUntilDate(Instant.now().plusMillis(duration.toMillis()));
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RestrictChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RestrictChatMember.java
@@ -1,5 +1,6 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
@@ -8,6 +9,9 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -89,9 +93,23 @@ public class RestrictChatMember extends BotApiMethod<Boolean> {
         return untilDate;
     }
 
-    public RestrictChatMember setUntilDate(Integer untilDate) {
-        this.untilDate = untilDate;
+    public RestrictChatMember setUntilDate(Integer untilDateInSeconds) {
+        this.untilDate = untilDateInSeconds;
         return this;
+    }
+
+    @JsonIgnore
+    public RestrictChatMember setUntilDate(Instant instant) {
+        return setUntilDate((int) instant.getEpochSecond());
+    }
+
+    @JsonIgnore
+    public RestrictChatMember setUntilDate(ZonedDateTime date) {
+        return setUntilDate(date.toInstant());
+    }
+
+    public RestrictChatMember forTimePeriod(Duration duration) {
+        return setUntilDate(Instant.now().plusMillis(duration.toMillis()));
     }
 
     public Boolean getCanSendMessages() {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/ChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/ChatMember.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 
+import java.time.Instant;
+
 /**
  * @author Ruben Bermudez
  * @version 1.0
@@ -75,6 +77,13 @@ public class ChatMember implements BotApiObject {
 
     public Integer getUntilDate() {
         return untilDate;
+    }
+
+    public Instant getUntilDateAsInstant() {
+        if (untilDate == null) {
+            return null;
+        }
+        return Instant.ofEpochSecond(untilDate);
     }
 
     public Boolean getCanBeEdited() {


### PR DESCRIPTION
It's always a little hard to understand what value should be passed to `setUntilDate` method in `RestrictChatMember` and `KickChatMember`. This pull request adds three convenient methods:
 - `setUntilDate(Instant instant)`
 - `setUntilDate(ZonedDateTime date)`
 - `forTimePeriod(Duration duration)`

Here is some examples:
```java
// Kick for 3 weeks from now
new KickChatMember(charId, userId)
        .setUntilDate(Instant.now().plus(Period.ofWeeks(3)))

// Restrict media messages until 23 dec 2018 08:00 JST
new RestrictChatMember(charId, userId)
        .setCanSendMediaMessages(false)
        .setUntilDate(ZonedDateTime.of(
                LocalDate.of(2018, Month.DECEMBER, 23),
                LocalTime.of(8, 0),
                ZoneId.of("Asia/Tokyo")
        ))

// Kick for 3 days and 12 hours
new KickChatMember(charId, userId)
        .forTimePeriod(Duration.ofDays(3).plusHours(12))
```