### PR TITLE
Back up maps in the database as a collection of key value pairs

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/BackupMap.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/BackupMap.java
@@ -1,0 +1,36 @@
+package org.telegram.abilitybots.api.db;
+
+import org.telegram.abilitybots.api.util.Pair;
+
+import java.util.*;
+
+public class BackupMap<K, V> extends AbstractCollection<Pair<K, V>> implements Collection<Pair<K, V>> {
+    private Collection<Pair<K, V>> entries = new HashSet<>();
+
+    public BackupMap(){}
+
+    public BackupMap(Map<K, V> map) {
+        map.forEach((key, value) -> entries.add(Pair.of(key, value)));
+    }
+
+    public Map<K, V> toMap() {
+        Map<K, V> map = new HashMap<>();
+        entries.forEach(e -> map.put(e.a(), e.b()));
+        return map;
+    }
+
+    @Override
+    public Iterator<Pair<K, V>> iterator() {
+        return entries.iterator();
+    }
+
+    @Override
+    public int size() {
+        return entries.size();
+    }
+
+    @Override
+    public boolean add(Pair<K, V> kvPair) {
+        return entries.add(kvPair);
+    }
+}

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/BackupMap.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/BackupMap.java
@@ -4,7 +4,7 @@ import org.telegram.abilitybots.api.util.Pair;
 
 import java.util.*;
 
-public class BackupMap<K, V> extends AbstractCollection<Pair<K, V>> implements Collection<Pair<K, V>> {
+final class BackupMap<K, V> extends AbstractCollection<Pair<K, V>> implements Collection<Pair<K, V>> {
     private Collection<Pair<K, V>> entries = new HashSet<>();
 
     public BackupMap(){}

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBContext.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBContext.java
@@ -198,7 +198,7 @@ public class MapDBContext implements DBContext {
         Set entrySet = (Set) value;
         getSet(name).addAll(entrySet);
       } else if (value instanceof BackupMap) {
-        Map<Object, Object> entryMap = ((BackupMap)value).toMap();
+        Map<Object, Object> entryMap = ((BackupMap) value).toMap();
         getMap(name).putAll(entryMap);
       } else if (value instanceof List) {
         List entryList = (List) value;

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBContext.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBContext.java
@@ -184,7 +184,7 @@ public class MapDBContext implements DBContext {
       else if (struct instanceof List)
         return Pair.of(entry.getKey(), newArrayList((List) struct));
       else if (struct instanceof Map)
-        return Pair.of(entry.getKey(), newHashMap((Map) struct));
+        return Pair.of(entry.getKey(), new BackupMap((Map) struct));
       else
         return Pair.of(entry.getKey(), struct);
     }).collect(toMap(pair -> (String) pair.a(), Pair::b));
@@ -197,17 +197,8 @@ public class MapDBContext implements DBContext {
       if (value instanceof Set) {
         Set entrySet = (Set) value;
         getSet(name).addAll(entrySet);
-      } else if (value instanceof Map) {
-        Map<Object, Object> entryMap = (Map) value;
-
-        // TODO: This is ugly
-        // Special handling of USERS since the key is an integer. JSON by default considers a map a JSONObject.
-        // Keys are serialized and deserialized as String
-        if (name.equals(USERS))
-          entryMap = entryMap.entrySet().stream()
-              .map(entry -> Pair.of(Integer.parseInt(entry.getKey().toString()), entry.getValue()))
-              .collect(toMap(Pair::a, Pair::b));
-
+      } else if (value instanceof BackupMap) {
+        Map<Object, Object> entryMap = ((BackupMap)value).toMap();
         getMap(name).putAll(entryMap);
       } else if (value instanceof List) {
         List entryList = (List) value;


### PR DESCRIPTION
Because the JSON (de)serializer only uses strings as keys, there are problems when using other types as keys. (As indicated by the workaround for the USERS map with long keys in the old code)

By backing up all maps as a collection of key value pairs and restoring them correctly as maps, all serializeable objects could be used as keys without problems.