### PR TITLE
Fixed case insensitive usernames

### DIFF
--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
@@ -22,16 +22,14 @@ import java.util.function.BiConsumer;
  */
 public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingBot implements ICommandRegistry {
     private final CommandRegistry commandRegistry;
-    private String botUsername;
 
     /**
      * Creates a TelegramLongPollingCommandBot using default options
      * Use ICommandRegistry's methods on this bot to register commands
      *
-     * @param botUsername Username of the bot
      */
-    public TelegramLongPollingCommandBot(String botUsername) {
-        this(ApiContext.getInstance(DefaultBotOptions.class), botUsername);
+    public TelegramLongPollingCommandBot() {
+        this(ApiContext.getInstance(DefaultBotOptions.class));
     }
 
     /**
@@ -40,10 +38,9 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
      * Use ICommandRegistry's methods on this bot to register commands
      *
      * @param options     Bot options
-     * @param botUsername Username of the bot
      */
-    public TelegramLongPollingCommandBot(DefaultBotOptions options, String botUsername) {
-        this(options, true, botUsername);
+    public TelegramLongPollingCommandBot(DefaultBotOptions options) {
+        this(options, true);
     }
 
     /**
@@ -53,11 +50,9 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
      * @param options                   Bot options
      * @param allowCommandsWithUsername true to allow commands with parameters (default),
      *                                  false otherwise
-     * @param botUsername               bot username of this bot
      */
-    public TelegramLongPollingCommandBot(DefaultBotOptions options, boolean allowCommandsWithUsername, String botUsername) {
+    public TelegramLongPollingCommandBot(DefaultBotOptions options, boolean allowCommandsWithUsername) {
         super(options);
-        this.botUsername = botUsername;
         this.commandRegistry = new CommandRegistry(allowCommandsWithUsername, this.getBotUsername());
     }
 

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
@@ -58,7 +58,7 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
     public TelegramLongPollingCommandBot(DefaultBotOptions options, boolean allowCommandsWithUsername, String botUsername) {
         super(options);
         this.botUsername = botUsername;
-        this.commandRegistry = new CommandRegistry(allowCommandsWithUsername, botUsername);
+        this.commandRegistry = new CommandRegistry(allowCommandsWithUsername, this.getBotUsername());
     }
 
     @Override
@@ -143,9 +143,7 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
      * @return Bot username
      */
     @Override
-    public final String getBotUsername() {
-        return botUsername;
-    }
+    public abstract String getBotUsername();
 
     /**
      * Process all updates, that are not commands.

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
@@ -22,6 +22,7 @@ import java.util.function.BiConsumer;
  */
 public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingBot implements ICommandRegistry {
     private final CommandRegistry commandRegistry;
+    private String botUsername;
 
     /**
      * Creates a TelegramLongPollingCommandBot using default options
@@ -30,6 +31,19 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
      */
     public TelegramLongPollingCommandBot() {
         this(ApiContext.getInstance(DefaultBotOptions.class));
+    }
+
+    /**
+     * Creates a TelegramLongPollingCommandBot using default options
+     * Use ICommandRegistry's methods on this bot to register commands
+     *
+     * @param botUsername Username of the bot
+     * @deprecated Overwrite {@link #getBotUsername() getBotUsername} instead
+     */
+    @Deprecated
+    public TelegramLongPollingCommandBot(String botUsername){
+        this();
+        this.botUsername = botUsername;
     }
 
     /**
@@ -138,7 +152,9 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
      * @return Bot username
      */
     @Override
-    public abstract String getBotUsername();
+    public String getBotUsername(){
+        return this.botUsername;
+    };
 
     /**
      * Process all updates, that are not commands.

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/commands/CommandRegistry.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/commands/CommandRegistry.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 
 /**
  * This class manages all the commands for a bot. You can register and deregister commands on demand
@@ -122,7 +123,7 @@ public final class CommandRegistry implements ICommandRegistry {
      */
     private String removeUsernameFromCommandIfNeeded(String command) {
         if (allowCommandsWithUsername) {
-            return command.replace("@" + botUsername, "").trim();
+            return command.replaceAll("(?i)@" + Pattern.quote(botUsername), "").trim();
         }
         return command;
     }


### PR DESCRIPTION
Usernames in Telegram are case insensitive, eg fooBar is the same as FooBar.
So this bot framework should also ignore the case of the username and this PR fixes this.