### PR TITLE
AbilityBots: prevent nullPointerExceptions when using message flags

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
@@ -27,12 +27,12 @@ public enum Flag implements Predicate<Update> {
   CHOSEN_INLINE_QUERY(Update::hasChosenInlineQuery),
 
   // Message Flags
-  REPLY(upd -> upd.hasMessage() && upd.getMessage().isReply()),
-  DOCUMENT(upd -> upd.hasMessage() && upd.getMessage().hasDocument()),
-  TEXT(upd -> upd.hasMessage() && upd.getMessage().hasText()),
-  PHOTO(upd -> upd.hasMessage() && upd.getMessage().hasPhoto()),
-  LOCATION(upd -> upd.hasMessage() && upd.getMessage().hasLocation()),
-  CAPTION(upd -> upd.hasMessage() && nonNull(upd.getMessage().getCaption()));
+  REPLY(upd -> MESSAGE.test(upd) && upd.getMessage().isReply()),
+  DOCUMENT(upd -> MESSAGE.test(upd) && upd.getMessage().hasDocument()),
+  TEXT(upd -> MESSAGE.test(upd) && upd.getMessage().hasText()),
+  PHOTO(upd -> MESSAGE.test(upd) && upd.getMessage().hasPhoto()),
+  LOCATION(upd -> MESSAGE.test(upd) && upd.getMessage().hasLocation()),
+  CAPTION(upd -> MESSAGE.test(upd) && nonNull(upd.getMessage().getCaption()));
 
   private final Predicate<Update> predicate;
 

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
@@ -27,12 +27,12 @@ public enum Flag implements Predicate<Update> {
   CHOSEN_INLINE_QUERY(Update::hasChosenInlineQuery),
 
   // Message Flags
-  REPLY(update -> update.getMessage().isReply()),
-  DOCUMENT(upd -> upd.getMessage().hasDocument()),
-  TEXT(upd -> upd.getMessage().hasText()),
-  PHOTO(upd -> upd.getMessage().hasPhoto()),
-  LOCATION(upd -> upd.getMessage().hasLocation()),
-  CAPTION(upd -> nonNull(upd.getMessage().getCaption()));
+  REPLY(upd -> upd.hasMessage() && upd.getMessage().isReply()),
+  DOCUMENT(upd -> upd.hasMessage() && upd.getMessage().hasDocument()),
+  TEXT(upd -> upd.hasMessage() && upd.getMessage().hasText()),
+  PHOTO(upd -> upd.hasMessage() && upd.getMessage().hasPhoto()),
+  LOCATION(upd -> upd.hasMessage() && upd.getMessage().hasLocation()),
+  CAPTION(upd -> upd.hasMessage() && nonNull(upd.getMessage().getCaption()));
 
   private final Predicate<Update> predicate;
 


### PR DESCRIPTION
When using only a message flag like `LOCATION` without `MESSAGE` first, a nullPointerException is thrown if a non-message update is received.

I believe that instead of throwing the exception, the massage flags like `LOCATION` or `REPLY` should just return false. This prevents bot developers from having to specify the redundant `MESSAGE` flag.

This PR fixes this bug by checking `hasMessage()` before calling `getMethod()`.