### PR TITLE
Fixed maven and gradle imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Just import add the library to your project with one of these options:
     <dependency>
         <groupId>org.telegram</groupId>
         <artifactId>telegrambots</artifactId>
-        <version>4.4.0</version>
+        <version>4.4.0.1</version>
     </dependency>
 ```
 
 ```gradle
-    compile "org.telegram:telegrambots:4.4.0"
+    compile "org.telegram:telegrambots:4.4.0.1"
 ```
 
   2. Using Jitpack from [here](https://jitpack.io/#rubenlagus/TelegramBots/4.4.0)


### PR DESCRIPTION
There is no 4.4.0 version available only 4.4.0.1
https://stackoverflow.com/questions/57669668/could-not-resolve-org-telegramtelegrambots4-4-0