### PR TITLE
upgrade spring boot to 2.2.1.RELEASE, replaced Optional bean with ObjectProvider in autoconfiguration

### DIFF
--- a/telegrambots-spring-boot-starter/pom.xml
+++ b/telegrambots-spring-boot-starter/pom.xml
@@ -70,7 +70,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
     </properties>
 
     <dependencies>

--- a/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/TelegramBotStarterConfiguration.java
+++ b/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/TelegramBotStarterConfiguration.java
@@ -2,8 +2,9 @@ package org.telegram.telegrambots.starter;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
+
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -11,12 +12,11 @@ import org.springframework.context.annotation.Configuration;
 import org.telegram.telegrambots.meta.TelegramBotsApi;
 import org.telegram.telegrambots.meta.generics.LongPollingBot;
 import org.telegram.telegrambots.meta.generics.WebhookBot;
-
 /**
  * #TelegramBotsApi added to spring context as well
  */
 @Configuration
-@ConditionalOnProperty(prefix="telegrambots",name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "telegrambots", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class TelegramBotStarterConfiguration {
 
     @Bean
@@ -26,12 +26,12 @@ public class TelegramBotStarterConfiguration {
     }
 
     @Bean
-	@ConditionalOnMissingBean
-	public TelegramBotInitializer telegramBotInitializer(TelegramBotsApi telegramBotsApi,
-										Optional<List<LongPollingBot>> longPollingBots,
-							            Optional<List<WebhookBot>> webHookBots) {
-		return new TelegramBotInitializer(telegramBotsApi,
-						longPollingBots.orElseGet(Collections::emptyList),
-						webHookBots.orElseGet(Collections::emptyList));
+    @ConditionalOnMissingBean
+    public TelegramBotInitializer telegramBotInitializer(TelegramBotsApi telegramBotsApi,
+                                                         ObjectProvider<List<LongPollingBot>> longPollingBots,
+                                                         ObjectProvider<List<WebhookBot>> webHookBots) {
+        return new TelegramBotInitializer(telegramBotsApi,
+                longPollingBots.getIfAvailable(Collections::emptyList),
+                webHookBots.getIfAvailable(Collections::emptyList));
     }
 }


### PR DESCRIPTION
upgrade spring boot to 2.2.0.RELEASE
replaced Optional bean with ObjectProvider in autoconfiguration