### PR TITLE
User/ChatId calculation is added for PreCheckoutQuery.

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
@@ -25,6 +25,7 @@ public enum Flag implements Predicate<Update> {
   EDITED_MESSAGE(Update::hasEditedMessage),
   INLINE_QUERY(Update::hasInlineQuery),
   CHOSEN_INLINE_QUERY(Update::hasChosenInlineQuery),
+  PRECHECKOUT_QUERY(Update::hasPreCheckoutQuery),
 
   // Message Flags
   REPLY(upd -> MESSAGE.test(upd) && upd.getMessage().isReply()),

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -69,6 +69,8 @@ public final class AbilityUtils {
       return update.getEditedMessage().getFrom();
     } else if (CHOSEN_INLINE_QUERY.test(update)) {
       return update.getChosenInlineQuery().getFrom();
+    } else if (PRECHECKOUT_QUERY.test(update)) {
+      return update.getPreCheckoutQuery().getFrom();
     } else {
       throw new IllegalStateException("Could not retrieve originating user from update");
     }
@@ -140,6 +142,8 @@ public final class AbilityUtils {
       return update.getEditedMessage().getChatId();
     } else if (CHOSEN_INLINE_QUERY.test(update)) {
       return (long) update.getChosenInlineQuery().getFrom().getId();
+    } else if (PRECHECKOUT_QUERY.test(update)) {
+      return (long) update.getPreCheckoutQuery().getFrom().getId();
     } else {
       throw new IllegalStateException("Could not retrieve originating chat ID from update");
     }


### PR DESCRIPTION
I am new to this library, please correct me if missed something.

At the moment, when `Invoice` is created,  `PrecheckoutQuery` is received, but fails: it can't calculate User (`BotAbilities.getUser` and `BotAbilities.getChatId`). 

Hereis the fix provided.