### PR TITLE
Prevent loss of DB state after bot termination

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -3,9 +3,6 @@ package org.telegram.abilitybots.api.bot;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multimap;
-import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -192,6 +189,9 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
                 .map(this::getContext)
                 .map(this::consumeUpdate)
                 .forEach(this::postConsumption);
+
+        // Commit to DB now after all the actions have been dealt
+        db.commit();
 
         long processingTime = System.currentTimeMillis() - millisStarted;
         log.info(format("[%s] Processing of update [%s] ended at %s%n---> Processing time: [%d ms] <---%n", botUsername, update.getUpdateId(), now(), processingTime));
@@ -480,7 +480,6 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
             return user;
         });
 
-        db.commit();
         return update;
     }
 

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/DefaultAbilities.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/DefaultAbilities.java
@@ -60,7 +60,6 @@ import static org.telegram.abilitybots.api.util.AbilityMessageCodes.ABILITY_UNBA
 import static org.telegram.abilitybots.api.util.AbilityMessageCodes.ABILITY_UNBAN_SUCCESS;
 import static org.telegram.abilitybots.api.util.AbilityMessageCodes.USER_NOT_FOUND;
 import static org.telegram.abilitybots.api.util.AbilityUtils.addTag;
-import static org.telegram.abilitybots.api.util.AbilityUtils.commitTo;
 import static org.telegram.abilitybots.api.util.AbilityUtils.escape;
 import static org.telegram.abilitybots.api.util.AbilityUtils.getLocalizedMessage;
 import static org.telegram.abilitybots.api.util.AbilityUtils.shortName;
@@ -288,7 +287,6 @@ public final class DefaultAbilities implements AbilityExtension {
             sendMd(ABILITY_BAN_SUCCESS, ctx, escape(bannedUser));
           }
         })
-        .post(commitTo(bot.db))
         .build();
   }
 
@@ -315,7 +313,6 @@ public final class DefaultAbilities implements AbilityExtension {
             bot.silent.sendMd(getLocalizedMessage(ABILITY_UNBAN_SUCCESS, ctx.user().getLanguageCode(), escape(username)), ctx.chatId());
           }
         })
-        .post(commitTo(bot.db))
         .build();
   }
 
@@ -339,7 +336,7 @@ public final class DefaultAbilities implements AbilityExtension {
             admins.add(userId);
             sendMd(ABILITY_PROMOTE_SUCCESS, ctx, escape(username));
           }
-        }).post(commitTo(bot.db))
+        })
         .build();
   }
 
@@ -363,7 +360,6 @@ public final class DefaultAbilities implements AbilityExtension {
             sendMd(ABILITY_DEMOTE_FAIL, ctx, escape(username));
           }
         })
-        .post(commitTo(bot.db))
         .build();
   }
 
@@ -389,7 +385,6 @@ public final class DefaultAbilities implements AbilityExtension {
             send(ABILITY_CLAIM_SUCCESS, ctx);
           }
         })
-        .post(commitTo(bot.db))
         .build();
   }
 


### PR DESCRIPTION
The call to `db.commit` must be done at the end of the pipeline. At the moment, it's used in the user addition logic which happens to be at the beginning of the pipeline.

Something like:
State 1 -> State 2 -> Bot Termination would make the bot start on State 1. This mostly affects ReplyFlows.