### PR TITLE
Add basic statistics to Abilities and Replies

### DIFF
--- a/TelegramBots.wiki/abilities/Advanced.md
+++ b/TelegramBots.wiki/abilities/Advanced.md
@@ -32,3 +32,6 @@ As an example, if you want to restrict the updates to photos only, then you may 
     return Flag.PHOTO;
   }
 ```
+
+## Statistics
+AbilityBot can accrue basic statistics about the usage of your abilities and replies. Simply `enableStats()` on an Ability builder or `enableStats(<name>)` on replies to activate this feature. Once activated, you may call `/stats` and the bot will print a basic list of statistics. At the moment, AbilityBot only tracks hits. In the future, this will be enhanced to track more stats.

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/DefaultAbilities.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/DefaultAbilities.java
@@ -26,6 +26,7 @@ import java.io.PrintStream;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.StringJoiner;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.MultimapBuilder.hashKeys;
@@ -76,6 +77,7 @@ public final class DefaultAbilities implements AbilityExtension {
   public static final String RECOVER = "recover";
   public static final String COMMANDS = "commands";
   public static final String REPORT = "report";
+  public static final String STATS = "stats";
   private static final Logger log = LoggerFactory.getLogger(DefaultAbilities.class);
   private final BaseAbilityBot bot;
 
@@ -180,6 +182,26 @@ public final class DefaultAbilities implements AbilityExtension {
   }
 
   /**
+   * @return the ability to report statistics for abilities and replies.
+   */
+  public Ability reportStats() {
+    return builder()
+        .name(STATS)
+        .locality(ALL)
+        .privacy(ADMIN)
+        .input(0)
+        .action(ctx -> {
+          String stats = bot.stats().entrySet().stream()
+              .map(entry -> String.format("%s: %d", entry.getKey(), entry.getValue().hits()))
+              .reduce(new StringJoiner("\n"), StringJoiner::add, StringJoiner::merge)
+              .toString();
+
+          bot.silent.send(stats, ctx.chatId());
+        })
+        .build();
+  }
+
+  /**
    * This backup ability returns the object defined by {@link DBContext#backup()} as a message document.
    * <p>
    * This is a high-profile ability and is restricted to the CREATOR only.
@@ -211,6 +233,7 @@ public final class DefaultAbilities implements AbilityExtension {
         })
         .build();
   }
+
 
   /**
    * Recovers the bot database using {@link DBContext#recover(Object)}.

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Ability.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Ability.java
@@ -42,13 +42,14 @@ public final class Ability {
   private final Locality locality;
   private final Privacy privacy;
   private final int argNum;
+  private final boolean statsEnabled;
   private final Consumer<MessageContext> action;
   private final Consumer<MessageContext> postAction;
   private final List<Reply> replies;
   private final List<Predicate<Update>> flags;
 
   @SafeVarargs
-  private Ability(String name, String info, Locality locality, Privacy privacy, int argNum, Consumer<MessageContext> action, Consumer<MessageContext> postAction, List<Reply> replies, Predicate<Update>... flags) {
+  private Ability(String name, String info, Locality locality, Privacy privacy, int argNum, boolean statsEnabled, Consumer<MessageContext> action, Consumer<MessageContext> postAction, List<Reply> replies, Predicate<Update>... flags) {
     checkArgument(!isEmpty(name), "Method name cannot be empty");
     checkArgument(!containsWhitespace(name), "Method name cannot contain spaces");
     checkArgument(isAlphanumeric(name), "Method name can only be alpha-numeric", name);
@@ -70,6 +71,7 @@ public final class Ability {
 
     this.postAction = postAction;
     this.replies = replies;
+    this.statsEnabled = statsEnabled;
   }
 
   public static AbilityBuilder builder() {
@@ -94,6 +96,10 @@ public final class Ability {
 
   public int tokens() {
     return argNum;
+  }
+
+  public boolean statsEnabled() {
+    return statsEnabled;
   }
 
   public Consumer<MessageContext> action() {
@@ -147,12 +153,14 @@ public final class Ability {
     private Privacy privacy;
     private Locality locality;
     private int argNum;
+    private boolean statsEnabled;
     private Consumer<MessageContext> action;
     private Consumer<MessageContext> postAction;
     private List<Reply> replies;
     private Predicate<Update>[] flags;
 
     private AbilityBuilder() {
+      statsEnabled = false;
       replies = newArrayList();
     }
 
@@ -186,6 +194,11 @@ public final class Ability {
       return this;
     }
 
+    public AbilityBuilder enableStats() {
+      statsEnabled = true;
+      return this;
+    }
+
     public AbilityBuilder privacy(Privacy privacy) {
       this.privacy = privacy;
       return this;
@@ -199,6 +212,11 @@ public final class Ability {
     @SafeVarargs
     public final AbilityBuilder reply(Consumer<Update> action, Predicate<Update>... conditions) {
       replies.add(Reply.of(action, conditions));
+      return this;
+    }
+
+    public final AbilityBuilder reply(Reply reply) {
+      replies.add(reply);
       return this;
     }
 
@@ -216,7 +234,7 @@ public final class Ability {
     }
 
     public Ability build() {
-      return new Ability(name, info, locality, privacy, argNum, action, postAction, replies, flags);
+      return new Ability(name, info, locality, privacy, argNum, statsEnabled, action, postAction, replies, flags);
     }
   }
 }

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Reply.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Reply.java
@@ -26,12 +26,15 @@ import static java.util.Arrays.asList;
 public class Reply {
   public final List<Predicate<Update>> conditions;
   public final Consumer<Update> action;
+  private boolean statsEnabled;
+  private String name;
 
   Reply(List<Predicate<Update>> conditions, Consumer<Update> action) {
     this.conditions = ImmutableList.<Predicate<Update>>builder()
         .addAll(conditions)
         .build();
     this.action = action;
+    statsEnabled = false;
   }
 
   public static Reply of(Consumer<Update> action, List<Predicate<Update>> conditions) {
@@ -63,6 +66,20 @@ public class Reply {
 
   public Stream<Reply> stream(){
     return Stream.of(this);
+  }
+
+  public Reply enableStats(String name) {
+    this.name = name;
+    statsEnabled = true;
+    return this;
+  }
+
+  public boolean statsEnabled() {
+    return statsEnabled;
+  }
+
+  public String name() {
+    return name;
   }
 
   @Override

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Stats.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Stats.java
@@ -1,0 +1,64 @@
+package org.telegram.abilitybots.api.objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import org.json.JSONPropertyIgnore;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Basic POJO to track ability and reply hits. The current implementation is NOT thread safe.
+ *
+ * @author Abbas Abou Daya
+ */
+public final class Stats implements Serializable {
+  @JsonProperty
+  private final String name;
+  @JsonProperty
+  private long hits;
+
+  private Stats(String name) {
+    this.name = name;
+  }
+
+  @JsonCreator
+  public static Stats createStats(@JsonProperty("name") String name, @JsonProperty("hits") long hits) {
+    return new Stats(name);
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public long hits() {
+    return hits;
+  }
+
+  public void hit() {
+    hits++;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Stats that = (Stats) o;
+    return hits == that.hits &&
+        Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, hits);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("hits", hits)
+        .toString();
+  }
+}

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.telegram.abilitybots.api.db.DBContext;
 import org.telegram.abilitybots.api.objects.*;
 import org.telegram.abilitybots.api.sender.MessageSender;
@@ -128,6 +129,30 @@ public class AbilityBotTest {
     deleteQuietly(new java.io.File("backup.json"));
 
     verify(sender, times(1)).sendDocument(any());
+  }
+
+  @Test
+  void canReportStatistics() {
+    MessageContext context = defaultContext();
+
+    defaultAbs.reportStats().action().accept(context);
+
+    verify(silent, times(1)).send("count: 0\nmustreply: 0", GROUP_ID);
+  }
+
+  @Test
+  void canReportUpdatedStatistics() {
+    Update upd1 = mockFullUpdate(bot, CREATOR, "/count 1 2 3 4");
+    bot.onUpdateReceived(upd1);
+    Update upd2 = mockFullUpdate(bot, CREATOR, "must reply");
+    bot.onUpdateReceived(upd2);
+
+    Mockito.reset(silent);
+
+    Update statUpd = mockFullUpdate(bot, CREATOR, "/stats");
+    bot.onUpdateReceived(statUpd);
+
+    verify(silent, times(1)).send("count: 1\nmustreply: 1", CREATOR.getId());
   }
 
   @Test
@@ -553,7 +578,7 @@ public class AbilityBotTest {
 
     defaultAbs.commands().action().accept(creatorCtx);
 
-    String expected = "PUBLIC\n/commands\n/count\n/default - dis iz default command\n/group\n/test\nADMIN\n/admin\n/ban\n/demote\n/promote\n/unban\nCREATOR\n/backup\n/claim\n/recover\n/report";
+    String expected = "PUBLIC\n/commands\n/count\n/default - dis iz default command\n/group\n/test\nADMIN\n/admin\n/ban\n/demote\n/promote\n/stats\n/unban\nCREATOR\n/backup\n/claim\n/recover\n/report";
     verify(silent, times(1)).send(expected, GROUP_ID);
   }
 

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/DefaultBot.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/DefaultBot.java
@@ -3,6 +3,7 @@ package org.telegram.abilitybots.api.bot;
 import org.telegram.abilitybots.api.db.DBContext;
 import org.telegram.abilitybots.api.objects.Ability;
 import org.telegram.abilitybots.api.objects.Ability.AbilityBuilder;
+import org.telegram.abilitybots.api.objects.Reply;
 import org.telegram.abilitybots.api.toggle.AbilityToggle;
 
 import static org.telegram.abilitybots.api.objects.Ability.builder;
@@ -41,7 +42,7 @@ public class DefaultBot extends AbilityBot {
     return getDefaultBuilder()
         .name(DEFAULT)
         .info("dis iz default command")
-        .reply(upd -> silent.send("reply", upd.getMessage().getChatId()), MESSAGE, update -> update.getMessage().getText().equals("must reply"))
+        .reply(Reply.of(upd -> silent.send("reply", upd.getMessage().getChatId()), MESSAGE, update -> update.getMessage().getText().equals("must reply")).enableStats("mustreply"))
         .reply(upd -> silent.send("reply", upd.getCallbackQuery().getMessage().getChatId()), CALLBACK_QUERY)
         .build();
   }
@@ -67,6 +68,7 @@ public class DefaultBot extends AbilityBot {
         .privacy(PUBLIC)
         .locality(USER)
         .input(4)
+        .enableStats()
         .build();
   }
 


### PR DESCRIPTION
Adds the `/stats` command to list the number of times the abilities or replies have been called.

Format of the message is as follows:
```
<NAME>: <#HITS>
ability1: 5
reply1: 10
```