### PR TITLE
Revert: Added deprecated constructor with the old style (e526b9db)

### DIFF
--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
@@ -22,7 +22,6 @@ import java.util.function.BiConsumer;
  */
 public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingBot implements ICommandRegistry {
     private final CommandRegistry commandRegistry;
-    private String botUsername;
 
     /**
      * Creates a TelegramLongPollingCommandBot using default options
@@ -31,19 +30,6 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
      */
     public TelegramLongPollingCommandBot() {
         this(ApiContext.getInstance(DefaultBotOptions.class));
-    }
-
-    /**
-     * Creates a TelegramLongPollingCommandBot using default options
-     * Use ICommandRegistry's methods on this bot to register commands
-     *
-     * @param botUsername Username of the bot
-     * @deprecated Overwrite {@link #getBotUsername() getBotUsername} instead
-     */
-    @Deprecated
-    public TelegramLongPollingCommandBot(String botUsername){
-        this();
-        this.botUsername = botUsername;
     }
 
     /**
@@ -152,9 +138,7 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
      * @return Bot username
      */
     @Override
-    public String getBotUsername(){
-        return this.botUsername;
-    };
+    public abstract String getBotUsername();
 
     /**
      * Process all updates, that are not commands.


### PR DESCRIPTION
This commit causes a bug if using the normal constructors without
overriding getBotUsername and since it's no longer abstract it doesn't force you to implement the method,
even though it is needed in any case aside from the deprecated one