### PR TITLE
Fix gradle string in ability example

### DIFF
--- a/TelegramBots.wiki/abilities/Simple-Example.md
+++ b/TelegramBots.wiki/abilities/Simple-Example.md
@@ -14,7 +14,7 @@ As with any Java project, you will need to set your dependencies.
 ```
 * **Gradle**
 ```groovy
-  compile group: 'org.telegram', name: 'telegrambots-abilities', version: 'permissions'
+  implementation group: 'org.telegram', name: 'telegrambots-abilities', version: '4.7'
 ```
 * [JitPack](https://jitpack.io/#rubenlagus/TelegramBots)
     


### PR DESCRIPTION
The current version is 4.7.
Also the compile configuration is deprecated and
was replaced by implementation.

See:
https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations