### PR TITLE
Fix handling of poll updates without user information

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -465,6 +465,10 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
 
     Update addUser(Update update) {
         User endUser = AbilityUtils.getUser(update);
+        if (endUser.equals(EMPTY_USER)) {
+            // Can't add an empty user, return the update as is
+            return update;
+        }
 
         users().compute(endUser.getId(), (id, user) -> {
             if (user == null) {

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Flag.java
@@ -25,6 +25,10 @@ public enum Flag implements Predicate<Update> {
   EDITED_MESSAGE(Update::hasEditedMessage),
   INLINE_QUERY(Update::hasInlineQuery),
   CHOSEN_INLINE_QUERY(Update::hasChosenInlineQuery),
+  SHIPPING_QUERY(Update::hasShippingQuery),
+  PRECHECKOUT_QUERY(Update::hasPreCheckoutQuery),
+  POLL(Update::hasPoll),
+  POLL_ANSWER(Update::hasPollAnswer),
 
   // Message Flags
   REPLY(upd -> MESSAGE.test(upd) && upd.getMessage().isReply()),

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -24,6 +24,8 @@ import static org.telegram.abilitybots.api.objects.Flag.*;
  * Helper and utility methods
  */
 public final class AbilityUtils {
+  public static User EMPTY_USER = new User();
+
   private AbilityUtils() {
 
   }
@@ -69,6 +71,14 @@ public final class AbilityUtils {
       return update.getEditedMessage().getFrom();
     } else if (CHOSEN_INLINE_QUERY.test(update)) {
       return update.getChosenInlineQuery().getFrom();
+    } else if (SHIPPING_QUERY.test(update)) {
+      return update.getShippingQuery().getFrom();
+    } else if (PRECHECKOUT_QUERY.test(update)) {
+      return update.getPreCheckoutQuery().getFrom();
+    } else if (POLL_ANSWER.test(update)) {
+      return update.getPollAnswer().getUser();
+    } else if (POLL.test(update)) {
+      return EMPTY_USER;
     } else {
       throw new IllegalStateException("Could not retrieve originating user from update");
     }


### PR DESCRIPTION
This PR addresses the #749 issue. Some updates don't have user info and AbilityBot as it is now leverages the user field to do some DB checks.

This removes the requirement for updates that have polls only.