### PR TITLE
Fix processing updates with no user info

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -180,6 +180,7 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
                 .filter(this::checkBlacklist)
                 .map(this::addUser)
                 .filter(this::filterReply)
+                .filter(this::hasUser)
                 .map(this::getAbility)
                 .filter(this::validateAbility)
                 .filter(this::checkPrivacy)
@@ -485,6 +486,12 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
         });
 
         return update;
+    }
+
+    private boolean hasUser(Update update) {
+        // Valid updates without users should return an empty user
+        // Updates that are not recognized by the getUser method will throw an exception
+        return !AbilityUtils.getUser(update).equals(EMPTY_USER);
     }
 
     private void updateUserId(User oldUser, User newUser) {

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -156,6 +156,8 @@ public final class AbilityUtils {
       return (long) update.getPreCheckoutQuery().getFrom().getId();
     } else if (POLL_ANSWER.test(update)) {
       return (long) update.getPollAnswer().getUser().getId();
+    } else if (POLL.test(update)) {
+      return (long) EMPTY_USER.getId();
     } else {
       throw new IllegalStateException("Could not retrieve originating chat ID from update");
     }

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -150,6 +150,12 @@ public final class AbilityUtils {
       return update.getEditedMessage().getChatId();
     } else if (CHOSEN_INLINE_QUERY.test(update)) {
       return (long) update.getChosenInlineQuery().getFrom().getId();
+    } else if (SHIPPING_QUERY.test(update)) {
+      return (long) update.getShippingQuery().getFrom().getId();
+    } else if (PRECHECKOUT_QUERY.test(update)) {
+      return (long) update.getPreCheckoutQuery().getFrom().getId();
+    } else if (POLL_ANSWER.test(update)) {
+      return (long) update.getPollAnswer().getUser().getId();
     } else {
       throw new IllegalStateException("Could not retrieve originating chat ID from update");
     }
@@ -170,10 +176,8 @@ public final class AbilityUtils {
       return update.getEditedChannelPost().isUserMessage();
     } else if (EDITED_MESSAGE.test(update)) {
       return update.getEditedMessage().isUserMessage();
-    } else if (CHOSEN_INLINE_QUERY.test(update) || INLINE_QUERY.test(update)) {
-      return true;
     } else {
-      throw new IllegalStateException("Could not retrieve update context origin (user/group)");
+      return true;
     }
   }
 

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -24,7 +24,7 @@ import static org.telegram.abilitybots.api.objects.Flag.*;
  * Helper and utility methods
  */
 public final class AbilityUtils {
-  public static User EMPTY_USER = new User();
+  public static User EMPTY_USER = new User(0, "", false, "", "", "");
 
   private AbilityUtils() {
 

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
@@ -152,6 +153,16 @@ public class AbilityBotTest {
             // looking for IllegalStateExceptions thrown by the method
           }
         });
+  }
+
+  @Test
+  void getChatIdCanHandleAllKindsOfUpdates() {
+    handlesAllUpdates(AbilityUtils::getUser);
+  }
+
+  @Test
+  void getUserCanHandleAllKindsOfUpdates() {
+    handlesAllUpdates(AbilityUtils::getChatId);
   }
 
   @Test
@@ -606,6 +617,29 @@ public class AbilityBotTest {
 
     String expected = "PUBLIC\n/commands\n/count\n/default - dis iz default command\n/group\n/test";
     verify(silent, times(1)).send(expected, GROUP_ID);
+  }
+
+  private void handlesAllUpdates(Consumer<Update> utilMethod) {
+    Arrays.stream(Update.class.getMethods())
+        // filter to all these methods of hasXXX (hasPoll, hasMessage, etc...)
+        .filter(method -> method.getName().startsWith("has"))
+        // Gotta filter out hashCode
+        .filter(method -> method.getReturnType().getName().equals("boolean"))
+        .forEach(method -> {
+          Update update = mock(Update.class);
+          try {
+            // Mock the method and make sure it returns true so that it gets processed by the following method
+            when(method.invoke(update)).thenReturn(true);
+            // Call the function, throws an IllegalStateException if there's an update that can't be processed
+            utilMethod.accept(update);
+          } catch (IllegalStateException e) {
+            throw new RuntimeException(
+                format("Found an update variation that is not handled by the getChatId util method [%s]", method.getName()), e);
+          } catch (NullPointerException | ReflectiveOperationException e) {
+            // This is fine, the mock isn't complete and we're only
+            // looking for IllegalStateExceptions thrown by the method
+          }
+        });
   }
 
   private void mockUser(Update update, Message message, User user) {


### PR DESCRIPTION
This addresses #749 again. It spawns the EMPTY_USER with empty equivalent arguments and most importantly adds two more tests.