### PR TITLE
Fix reply flow registration when using ability definitions

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -277,7 +277,8 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
 
             // Replies can be standalone or attached to abilities, fetch those too
             Stream<Reply> abilityReplies = abilities.values().stream()
-                    .flatMap(ability -> ability.replies().stream());
+                    .flatMap(ability -> ability.replies().stream())
+                    .flatMap(Reply::stream);
 
             // Now create the replies registry (list)
             replies = Stream.concat(abilityReplies, extensionReplies).collect(

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Reply.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Reply.java
@@ -2,10 +2,8 @@ package org.telegram.abilitybots.api.objects;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -14,7 +12,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static java.util.Arrays.asList;
 
 /**
  * A reply consists of update conditionals and an action to be applied on the update.
@@ -35,6 +32,13 @@ public class Reply {
         .build();
     this.action = action;
     statsEnabled = false;
+  }
+
+  Reply(List<Predicate<Update>> conditions, Consumer<Update> action, String name) {
+    this(conditions, action);
+    if (Objects.nonNull(name)) {
+      enableStats(name);
+    }
   }
 
   public static Reply of(Consumer<Update> action, List<Predicate<Update>> conditions) {

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ReplyFlowTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ReplyFlowTest.java
@@ -5,17 +5,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.telegram.abilitybots.api.db.DBContext;
-import org.telegram.abilitybots.api.objects.Flag;
-import org.telegram.abilitybots.api.objects.Reply;
-import org.telegram.abilitybots.api.objects.ReplyFlow;
+import org.telegram.abilitybots.api.objects.*;
 import org.telegram.abilitybots.api.sender.MessageSender;
 import org.telegram.abilitybots.api.sender.SilentSender;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.polls.Poll;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -122,6 +123,35 @@ public class ReplyFlowTest {
     assertTrue(bot.filterReply(update));
   }
 
+  @Test
+  void replyFlowsAreWorkingWhenDefinedInAbilities() {
+    Update update1 = mockFullUpdate(bot, USER, "one");
+    Update update2 = mockFullUpdate(bot, USER, "two");
+    long chatId = getChatId(update1);
+
+    // Trigger and verify first reply stage
+    assertFalse(bot.filterReply(update1));
+
+    verify(silent, only()).send("First reply", chatId);
+    assertTrue(db.<Long, Integer>getMap(STATES).containsKey(chatId), "User is not in initial state");
+    // Resetting the mock now helps with verification later
+    reset(silent);
+
+    // Trigger and verify second reply stage
+    assertFalse(bot.filterReply(update2));
+
+    verify(silent, only()).send("Second reply", chatId);
+    assertFalse(db.<Long, Integer>getMap(STATES).containsKey(chatId), "User is still in a state");
+  }
+
+  @Test
+  void replyFlowsPertainNames() {
+    Update update1 = mockFullUpdate(bot, USER, "one");
+    long chatId = getChatId(update1);
+    Set<String> replyNames = bot.replies().stream().map(Reply::name).collect(Collectors.toSet());
+    replyNames.containsAll(newHashSet("FIRST", "SECOND"));
+  }
+
   public static class ReplyFlowBot extends AbilityBot {
 
     private ReplyFlowBot(String botToken, String botUsername, DBContext db) {
@@ -150,6 +180,33 @@ public class ReplyFlowTest {
           .onlyIf(hasMessageWith("wake up"))
           .next(leftflow)
           .next(saidRight)
+          .build();
+    }
+
+    public Ability replyFlowsWithAbility() {
+      Reply replyWithVk = ReplyFlow.builder(db, 2)
+          .enableStats("SECOND")
+          .action(upd -> {
+            silent.send("Second reply", upd.getMessage().getChatId());
+          })
+          .onlyIf(hasMessageWith("two"))
+          .build();
+
+      Reply replyWithNickname = ReplyFlow.builder(db, 1)
+          .enableStats("FIRST")
+          .action(upd -> {
+            silent.send("First reply", upd.getMessage().getChatId());
+          })
+          .onlyIf(hasMessageWith("one"))
+          .next(replyWithVk)
+          .build();
+
+      return Ability.builder()
+          .name("trigger")
+          .privacy(Privacy.PUBLIC)
+          .locality(Locality.ALL)
+          .action(ctx -> silent.send("I'm in an ability", ctx.chatId()))
+          .reply(replyWithNickname)
           .build();
     }
 


### PR DESCRIPTION
ReplyFlows don't fully work when defined in an ability. This PR fixes the issue by calling the required Reply::stream function that would return all the attached replies for a particular ReplyFlow.

Also in this PR, we're adding supports for stats in ReplyFlows. Simply, `enableStats` in a ReplyFlow builder and stats would be enabled.