### PR TITLE
Make TelegramLongPollingSessionBot can be use proxy

### DIFF
--- a/telegrambots-chat-session-bot/src/main/java/org/telegram/telegrambots/session/TelegramLongPollingSessionBot.java
+++ b/telegrambots-chat-session-bot/src/main/java/org/telegram/telegrambots/session/TelegramLongPollingSessionBot.java
@@ -5,6 +5,7 @@ import org.apache.shiro.session.UnknownSessionException;
 import org.apache.shiro.session.mgt.DefaultSessionManager;
 import org.apache.shiro.session.mgt.SessionContext;
 import org.apache.shiro.session.mgt.eis.AbstractSessionDAO;
+import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
@@ -18,10 +19,15 @@ public abstract class TelegramLongPollingSessionBot extends TelegramLongPollingB
     ChatIdConverter chatIdConverter;
 
     public TelegramLongPollingSessionBot(){
-        this(new DefaultChatIdConverter());
+        this(new DefaultChatIdConverter(),null);
     }
 
-    public TelegramLongPollingSessionBot(ChatIdConverter chatIdConverter){
+    public TelegramLongPollingSessionBot(DefaultBotOptions options) {
+        this(new DefaultChatIdConverter(),options);
+    }
+
+    public TelegramLongPollingSessionBot(ChatIdConverter chatIdConverter,DefaultBotOptions options){
+        super(options);
         this.setSessionManager(new DefaultSessionManager());
         this.setChatIdConverter(chatIdConverter);
         AbstractSessionDAO sessionDAO = (AbstractSessionDAO) sessionManager.getSessionDAO();


### PR DESCRIPTION
The TelegramLongPollingSessionBot  class can't use proxy,that prevents me from continuing to develop bot.