### PR TITLE
Wrap reply calls with a try-catch clause to avoid dynamic exceptions

### DIFF
--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ReplyFlowTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ReplyFlowTest.java
@@ -146,10 +146,8 @@ public class ReplyFlowTest {
 
   @Test
   void replyFlowsPertainNames() {
-    Update update1 = mockFullUpdate(bot, USER, "one");
-    long chatId = getChatId(update1);
     Set<String> replyNames = bot.replies().stream().map(Reply::name).collect(Collectors.toSet());
-    replyNames.containsAll(newHashSet("FIRST", "SECOND"));
+    assertTrue(replyNames.containsAll(newHashSet("FIRST", "SECOND")));
   }
 
   public static class ReplyFlowBot extends AbilityBot {
@@ -181,6 +179,16 @@ public class ReplyFlowTest {
           .next(leftflow)
           .next(saidRight)
           .build();
+    }
+
+    public Reply errantReply() {
+      return Reply.of(
+          upd -> {
+            throw new RuntimeException("Throwing an exception inside the update consumer");
+          },
+          upd -> {
+            throw new RuntimeException("Throwing an exception inside the reply conditions (flags)");
+          });
     }
 
     public Ability replyFlowsWithAbility() {


### PR DESCRIPTION
This PR addresses #776. Replies that technically threw exceptions were preventing all consecutive replies to execute and in fact ends the update processing. This PR fixes the issue by wrapping all reply condition checks and execution.