### PR TITLE
Make getUser a safer method by returning a non-null user

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -37,6 +37,7 @@ import static com.google.common.collect.Sets.difference;
 import static java.lang.String.format;
 import static java.time.ZonedDateTime.now;
 import static java.util.Arrays.stream;
+import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static java.util.regex.Pattern.compile;
@@ -402,8 +403,12 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
     }
 
     boolean checkBlacklist(Update update) {
-        Integer id = AbilityUtils.getUser(update).getId();
+        User user = getUser(update);
+        if (isNull(user)) {
+            return true;
+        }
 
+        int id = user.getId();
         return id == creatorId() || !blacklist().contains(id);
     }
 

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -17,6 +17,7 @@ import java.util.function.Predicate;
 import static java.util.ResourceBundle.Control.FORMAT_PROPERTIES;
 import static java.util.ResourceBundle.Control.getNoFallbackControl;
 import static java.util.ResourceBundle.getBundle;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.telegram.abilitybots.api.objects.Flag.*;
 
@@ -57,6 +58,10 @@ public final class AbilityUtils {
    * @throws IllegalStateException if the user could not be found
    */
   public static User getUser(Update update) {
+    return defaultIfNull(getUserElseThrow(update), EMPTY_USER);
+  }
+
+  private static User getUserElseThrow(Update update) {
     if (MESSAGE.test(update)) {
       return update.getMessage().getFrom();
     } else if (CALLBACK_QUERY.test(update)) {
@@ -199,16 +204,16 @@ public final class AbilityUtils {
     return update -> update.getMessage().getReplyToMessage().getText().equals(msg);
   }
 
-  public static String getLocalizedMessage(String messageCode, Locale locale, Object...arguments) {
+  public static String getLocalizedMessage(String messageCode, Locale locale, Object... arguments) {
     ResourceBundle bundle;
     if (locale == null) {
       bundle = getBundle("messages", Locale.ROOT);
     } else {
       try {
         bundle = getBundle(
-                "messages",
-                locale,
-                getNoFallbackControl(FORMAT_PROPERTIES));
+            "messages",
+            locale,
+            getNoFallbackControl(FORMAT_PROPERTIES));
       } catch (MissingResourceException e) {
         bundle = getBundle("messages", Locale.ROOT);
       }
@@ -217,7 +222,7 @@ public final class AbilityUtils {
     return MessageFormat.format(message, arguments);
   }
 
-  public static String getLocalizedMessage(String messageCode, String languageCode, Object...arguments){
+  public static String getLocalizedMessage(String messageCode, String languageCode, Object... arguments) {
     Locale locale = Strings.isNullOrEmpty(languageCode) ? null : Locale.forLanguageTag(languageCode);
     return getLocalizedMessage(messageCode, locale, arguments);
   }
@@ -247,8 +252,8 @@ public final class AbilityUtils {
    * The full name is identified as the concatenation of the first and last name, separated by a space.
    * This method can return an empty name if both first and last name are empty.
    *
-   * @return the full name of the user
    * @param user
+   * @return the full name of the user
    */
   public static String fullName(User user) {
     StringJoiner name = new StringJoiner(" ");
@@ -262,6 +267,6 @@ public final class AbilityUtils {
   }
 
   public static String escape(String username) {
-      return username.replace("_", "\\_");
+    return username.replace("_", "\\_");
   }
 }

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
@@ -644,6 +644,21 @@ public class AbilityBotTest {
     verify(silent, times(1)).send(expected, GROUP_ID);
   }
 
+  @Test
+  void canProcessChannelPosts() {
+    Update update = mock(Update.class);
+    Message message = mock(Message.class);
+    when(message.getChatId()).thenReturn(1L);
+
+    when(update.getChannelPost()).thenReturn(message);
+    when(update.hasChannelPost()).thenReturn(true);
+
+    bot.onUpdateReceived(update);
+
+    String expected = "test channel post";
+    verify(silent, times(1)).send(expected, 1);
+  }
+
   private void handlesAllUpdates(Consumer<Update> utilMethod) {
     Arrays.stream(Update.class.getMethods())
         // filter to all these methods of hasXXX (hasPoll, hasMessage, etc...)

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/DefaultBot.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/DefaultBot.java
@@ -3,6 +3,7 @@ package org.telegram.abilitybots.api.bot;
 import org.telegram.abilitybots.api.db.DBContext;
 import org.telegram.abilitybots.api.objects.Ability;
 import org.telegram.abilitybots.api.objects.Ability.AbilityBuilder;
+import org.telegram.abilitybots.api.objects.Flag;
 import org.telegram.abilitybots.api.objects.Reply;
 import org.telegram.abilitybots.api.toggle.AbilityToggle;
 
@@ -70,6 +71,12 @@ public class DefaultBot extends AbilityBot {
         .input(4)
         .enableStats()
         .build();
+  }
+
+  public Reply channelPostReply() {
+    return Reply.of(
+        upd -> silent.send("test channel post", upd.getChannelPost().getChatId()), Flag.CHANNEL_POST
+    );
   }
 
   public Ability testAbility() {


### PR DESCRIPTION
This PR addresses #772. Some code inside AbilityBot assumes that there's a user in an update. Channel posts are one counter example that don't have a user. Whenever `getId` of the user is called, it would NPE.

This amends the function to return an EMPTY_USER if the actual user is null.