### PR TITLE
Catch-all clauses should catch Throwable instead of Exception class.

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -599,7 +599,7 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
     boolean runSilently(Callable<Boolean> callable, String name) {
         try {
             return callable.call();
-        } catch(Exception ex) {
+        } catch(Throwable ex) {
             log.error(format("Reply [%s] failed to check for conditions. " +
                 "Make sure you're safeguarding against all possible updates.", name));
         }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
@@ -214,7 +214,7 @@ public class DefaultBotSession implements BotSession {
                             }
                             log.debug(e.getLocalizedMessage(), e);
                             interrupt();
-                        } catch (Exception global) {
+                        } catch (Throwable global) {
                             log.error(global.getLocalizedMessage(), global);
                             try {
                                 synchronized (lock) {
@@ -322,7 +322,7 @@ public class DefaultBotSession implements BotSession {
                 } catch (InterruptedException e) {
                     log.debug(e.getLocalizedMessage(), e);
                     interrupt();
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     log.error(e.getLocalizedMessage(), e);
                 }
             }


### PR DESCRIPTION
Base class for all exception is Throwable, and it's possible to skip some of them by catching only Exception.
e.g., throwing AssertionError will lead to thread termination