### PR TITLE
Webhook bots now print exceptions instead of ignoring them

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultExceptionMapper.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultExceptionMapper.java
@@ -1,0 +1,20 @@
+package org.telegram.telegrambots.updatesreceivers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Prints exceptions in webhook bots to stderr
+ *
+ * @author Mouamle
+ * @version 1.0
+ */
+public class DefaultExceptionMapper implements ExceptionMapper<Throwable> {
+
+    @Override
+    public Response toResponse(Throwable exception) {
+        exception.printStackTrace();
+        return Response.serverError().build();
+    }
+
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultExceptionMapper.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultExceptionMapper.java
@@ -1,5 +1,8 @@
 package org.telegram.telegrambots.updatesreceivers;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
@@ -10,11 +13,11 @@ import javax.ws.rs.ext.ExceptionMapper;
  * @version 1.0
  */
 public class DefaultExceptionMapper implements ExceptionMapper<Throwable> {
+    private static final Logger log = LoggerFactory.getLogger(DefaultExceptionMapper.class);
 
     @Override
     public Response toResponse(Throwable exception) {
-        exception.printStackTrace();
+        log.error("Exception caught: ", exception);
         return Response.serverError().build();
     }
-
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultWebhook.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultWebhook.java
@@ -52,6 +52,7 @@ public class DefaultWebhook implements Webhook {
         ResourceConfig rc = new ResourceConfig();
         rc.register(restApi);
         rc.register(JacksonFeature.class);
+        rc.register(DefaultExceptionMapper.class);
 
         final HttpServer grizzlyServer;
         if (keystoreServerFile != null && keystoreServerPwd != null) {


### PR DESCRIPTION
Made webhook bots print exceptions stack trace to stderr instead of silently swallowing them.

I'm making this PR because I recently had an issue with my bot when I deployed it, I started seeing so many "HTTP 500" responses upon checking the code nothing seemed wrong with it and no errors were being logged until I registered a custom `org.telegram.telegrambots.meta.generics.Webhook` implementation that registers an `ExceptionMapper` to print out the exception and return the error response, later I found out it was a null pointer exception in `onWebhookUpdateReceived`. 