### PR TITLE
Add timeout and limit for long-polling updates to DefaultBotOptions

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
@@ -26,6 +26,8 @@ public class DefaultBotOptions implements BotOptions {
     private ProxyType proxyType;
     private String proxyHost;
     private int proxyPort;
+    private int getUpdatesTimeout;
+    private int getUpdatesLimit;
 
     public enum ProxyType {
         NO_PROXY,
@@ -39,6 +41,8 @@ public class DefaultBotOptions implements BotOptions {
         baseUrl = ApiConstants.BASE_URL;
         httpContext = HttpClientContext.create();
         proxyType = ProxyType.NO_PROXY;
+        getUpdatesLimit = ApiConstants.GETUPDATES_TIMEOUT;
+        getUpdatesLimit = 100;
     }
 
     @Override
@@ -128,5 +132,21 @@ public class DefaultBotOptions implements BotOptions {
 
     public void setProxyPort(int proxyPort) {
         this.proxyPort = proxyPort;
+    }
+
+    public int getGetUpdatesTimeout() {
+        return getUpdatesTimeout;
+    }
+
+    public void setGetUpdatesTimeout(int getUpdatesTimeout) {
+        this.getUpdatesTimeout = getUpdatesTimeout;
+    }
+
+    public int getGetUpdatesLimit() {
+        return getUpdatesLimit;
+    }
+
+    public void setGetUpdatesLimit(int getUpdatesLimit) {
+        this.getUpdatesLimit = getUpdatesLimit;
     }
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
@@ -236,8 +236,8 @@ public class DefaultBotSession implements BotSession {
 
         private List<Update> getUpdatesFromServer() throws IOException {
             GetUpdates request = new GetUpdates()
-                    .setLimit(100)
-                    .setTimeout(ApiConstants.GETUPDATES_TIMEOUT)
+                    .setLimit(options.getGetUpdatesLimit())
+                    .setTimeout(options.getGetUpdatesTimeout())
                     .setOffset(lastReceivedUpdate + 1);
 
             if (options.getAllowedUpdates() != null) {


### PR DESCRIPTION
Just a little commit to make the long-polling timeout and long-polling limit configurable via the BotOptions. Mainly for Testing