### PR TITLE
Be able to access AbilityBot via MessageContext

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -129,6 +129,27 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
     }
 
     /**
+     * @return the database of this bot
+     */
+    public DBContext db() {
+        return db;
+    }
+
+    /**
+     * @return the message sender for this bot
+     */
+    public MessageSender sender() {
+        return sender;
+    }
+
+    /**
+     * @return the silent sender for this bot
+     */
+    public SilentSender silent() {
+        return silent;
+    }
+
+    /**
      * @return the map of <ID,User>
      */
     public Map<Integer, User> users() {
@@ -437,7 +458,7 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
         Update update = trio.a();
         User user = AbilityUtils.getUser(update);
 
-        return Pair.of(newContext(update, user, getChatId(update), trio.c()), trio.b());
+        return Pair.of(newContext(update, user, getChatId(update), this, trio.c()), trio.b());
     }
 
     boolean checkBlacklist(Update update) {

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/MessageContext.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/MessageContext.java
@@ -2,6 +2,7 @@ package org.telegram.abilitybots.api.objects;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import org.telegram.abilitybots.api.bot.BaseAbilityBot;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.User;
 
@@ -19,16 +20,18 @@ public class MessageContext {
   private final Long chatId;
   private final String[] arguments;
   private final Update update;
+  private final BaseAbilityBot bot;
 
-  private MessageContext(Update update, User user, Long chatId, String[] arguments) {
+  private MessageContext(Update update, User user, Long chatId, BaseAbilityBot bot, String[] arguments) {
     this.user = user;
     this.chatId = chatId;
     this.update = update;
+    this.bot = bot;
     this.arguments = arguments;
   }
 
-  public static MessageContext newContext(Update update, User user, Long chatId, String... arguments) {
-    return new MessageContext(update, user, chatId, arguments);
+  public static MessageContext newContext(Update update, User user, Long chatId, BaseAbilityBot bot, String... arguments) {
+    return new MessageContext(update, user, chatId, bot, arguments);
   }
 
   /**
@@ -43,6 +46,13 @@ public class MessageContext {
    */
   public Long chatId() {
     return chatId;
+  }
+
+  /**
+   * @return the bot in which this message is executed
+   */
+  public BaseAbilityBot bot() {
+    return bot;
   }
 
   /**

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
@@ -503,7 +503,7 @@ public class AbilityBotTest {
     mockUser(update, message, USER);
 
     Pair<MessageContext, Ability> actualPair = bot.getContext(trio);
-    Pair<MessageContext, Ability> expectedPair = Pair.of(newContext(update, USER, GROUP_ID, TEXT), ability);
+    Pair<MessageContext, Ability> expectedPair = Pair.of(newContext(update, USER, GROUP_ID, bot, TEXT), ability);
 
     assertEquals(expectedPair, actualPair, "Unexpected result when fetching for context");
   }
@@ -619,7 +619,7 @@ public class AbilityBotTest {
     when(update.hasMessage()).thenReturn(true);
     when(update.getMessage()).thenReturn(message);
     when(message.hasText()).thenReturn(true);
-    MessageContext creatorCtx = newContext(update, CREATOR, GROUP_ID);
+    MessageContext creatorCtx = newContext(update, CREATOR, GROUP_ID, bot);
 
     defaultAbs.commands().action().accept(creatorCtx);
 
@@ -636,7 +636,7 @@ public class AbilityBotTest {
     when(update.getMessage()).thenReturn(message);
     when(message.hasText()).thenReturn(true);
 
-    MessageContext userCtx = newContext(update, USER, GROUP_ID);
+    MessageContext userCtx = newContext(update, USER, GROUP_ID, bot);
 
     defaultAbs.commands().action().accept(userCtx);
 

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/TestUtils.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/TestUtils.java
@@ -43,6 +43,7 @@ public final class TestUtils {
   static MessageContext mockContext(User user, long groupId, String... args) {
     Update update = mock(Update.class);
     Message message = mock(Message.class);
+    BaseAbilityBot bot = mock(BaseAbilityBot.class);
 
     when(update.hasMessage()).thenReturn(true);
     when(update.getMessage()).thenReturn(message);
@@ -50,7 +51,7 @@ public final class TestUtils {
     when(message.getFrom()).thenReturn(user);
     when(message.hasText()).thenReturn(true);
 
-    return newContext(update, user, groupId, args);
+    return newContext(update, user, groupId, bot, args);
   }
 
   @NotNull


### PR DESCRIPTION
This pull request makes it possible to access the bot class through the MessageContext object. For instance:

```
public class UuidAbility implements AbilityExtension {

    public Ability createAbility() {
        return Ability.builder()
            .name("uuid")
            .info("Generates a UUID")
            .locality(Locality.USER)
            .privacy(Privacy.PUBLIC)
            .action(ctx -> ctx.bot().silent().send(UUID.randomUUID().toString(), ctx.chatId()))
            .build();
    }

}
```

As you can see in the action method I can now use `ctx.bot().silent()` to send a message.