### PR TITLE
Be able to add AbilityExtensions in Bot constructor

### DIFF
--- a/TelegramBots.wiki/abilities/Ability-Extensions.md
+++ b/TelegramBots.wiki/abilities/Ability-Extensions.md
@@ -38,3 +38,17 @@ public class MrBadGuy implements AbilityExtension {
     // Override creatorId
  }
 ```
+
+It's also possible to add extensions in the constructor by using the `addExtension()` or `addExtensions()` method:
+
+```java
+ public class YourAwesomeBot implements AbilityBot {
+
+    public YourAwesomeBot() {
+      super(/* pass required args ... */);
+      addExtensions(new MrGoodGuy(), new MrBadGuy());
+    }
+    
+    // Override creatorId
+ }
+```

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -106,7 +106,7 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
     private final String botUsername;
 
     // Ability registry
-    protected final List<AbilityExtension> extensions = new ArrayList<>();
+    private final List<AbilityExtension> extensions = new ArrayList<>();
     private Map<String, Ability> abilities;
     private Map<String, Stats> stats;
 
@@ -271,6 +271,18 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
 
     protected boolean allowContinuousText() {
         return false;
+    }
+
+    protected void addExtension(AbilityExtension extension) {
+        this.extensions.add(extension);
+    }
+
+    protected void addExtensions(AbilityExtension... extensions) {
+        this.extensions.addAll(Arrays.asList(extensions));
+    }
+
+    protected void addExtensions(Collection<AbilityExtension> extensions) {
+        this.extensions.addAll(extensions);
     }
 
     /**

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -106,6 +106,7 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
     private final String botUsername;
 
     // Ability registry
+    protected final List<AbilityExtension> extensions = new ArrayList<>();
     private Map<String, Ability> abilities;
     private Map<String, Stats> stats;
 
@@ -280,10 +281,10 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
     private void registerAbilities() {
         try {
             // Collect all classes that implement AbilityExtension declared in the bot
-            List<AbilityExtension> extensions = stream(getClass().getMethods())
+            extensions.addAll(stream(getClass().getMethods())
                     .filter(checkReturnType(AbilityExtension.class))
                     .map(returnExtension(this))
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toList()));
 
             // Add the bot itself as it is an AbilityExtension
             extensions.add(this);

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ExtensionTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ExtensionTest.java
@@ -32,6 +32,7 @@ class ExtensionTest {
     assertTrue(hasAbilityNamed("direct"), "Failed to find Ability in directly declared in root extension/bot");
     assertTrue(hasAbilityNamed("returningSuperClass0abc"), "Failed to find Ability in directly declared in extension returned by method returning the AbilityExtension class");
     assertTrue(hasAbilityNamed("returningSubClass0abc"), "Failed to find Ability in directly declared in extension returned by method returning the AbilityExtension subclass");
+    assertTrue(hasAbilityNamed("addedInConstructor0abc"), "Failed to find Ability in directly declared in extension added in the constructor");
   }
 
   private boolean hasAbilityNamed(String name) {
@@ -41,6 +42,7 @@ class ExtensionTest {
   public static class ExtensionUsingBot extends AbilityBot {
     ExtensionUsingBot() {
       super("", "", offlineInstance("testing"));
+      addExtension(new AbilityBotExtension("addedInConstructor"));
     }
 
     @Override


### PR DESCRIPTION
Currently it's only possible to add ability extensions by defining a method that returns an AbilityExtension. This PR allows to add extensions in the Bot constructor already. This is especially useful when using Spring Dependency Injection.

Together with my other Pull Requests [#810](https://github.com/rubenlagus/TelegramBots/pull/810) and [#812](https://github.com/rubenlagus/TelegramBots/pull/812) you can now create a Bot like this:

```
@Component
public class MyBot extends AbilityBot {

	private final MyBotConfig config;

	public MyBot(MyBotConfig config, List<AbilityExtension> extensions) {
		super(config.getToken(), config.getUsername(), MapDBContext.onlineInstance(config.getDbFile()));
		this.config = config;
		this.extensions.addAll(extensions);
	}

	@Override
	public int creatorId() {
		return config.getCreatorUserId();
	}

}
```

All ability extensions are now registered automatically if they are configured as a Spring Bean.