### PR TITLE
Change Ability name check according to Telegram bot API requirements

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Ability.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Ability.java
@@ -50,9 +50,8 @@ public final class Ability {
 
   @SafeVarargs
   private Ability(String name, String info, Locality locality, Privacy privacy, int argNum, boolean statsEnabled, Consumer<MessageContext> action, Consumer<MessageContext> postAction, List<Reply> replies, Predicate<Update>... flags) {
-    checkArgument(!isEmpty(name), "Method name cannot be empty");
-    checkArgument(!containsWhitespace(name), "Method name cannot contain spaces");
-    checkArgument(isAlphanumeric(name), "Method name can only be alpha-numeric", name);
+    checkArgument(isValidCommandName(name), "Method name can only contain alpha-numeric characters and underscores," +
+            " cannot be longer than 31 characters, empty or null", name);
     this.name = name;
     this.info = info;
 

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -269,4 +269,29 @@ public final class AbilityUtils {
   public static String escape(String username) {
     return username.replace("_", "\\_");
   }
+  
+  /**
+   * Checks if the passed string is a valid bot command according to the requirements of Telegram Bot API:
+   *    "A command must always start with the '/' symbol and may not be longer than 32 characters.
+   *    Commands can use latin letters, numbers and underscores."
+   *    (https://core.telegram.org/bots#commands)
+   *
+   * @param command String representation of a command to be checked for validity
+   * @return whether the command is valid
+   */
+  public static boolean isValidCommand(String command){
+    if (command == null || command.length() > 32) return false;
+    return command.matches("/[A-Za-z_0-9]+");
+  }
+
+  /**
+   * Checks if the passed String is a valid command name. Command name is text of a command without leading '/'
+   *
+   * @param commandName the command's name to be checked for validity
+   * @return whether the command's name is valid
+   */
+  public static boolean isValidCommandName(String commandName){
+    if (commandName == null || commandName.length() > 31) return false;
+    return commandName.matches("[A-Za-z_0-9]+");
+  }
 }

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/util/AbilityUtils.java
@@ -287,8 +287,8 @@ public final class AbilityUtils {
   /**
    * Checks if the passed String is a valid command name. Command name is text of a command without leading '/'
    *
-   * @param commandName the command's name to be checked for validity
-   * @return whether the command's name is valid
+   * @param commandName the command name to be checked for validity
+   * @return whether the command name is valid
    */
   public static boolean isValidCommandName(String commandName){
     if (commandName == null || commandName.length() > 31) return false;


### PR DESCRIPTION
Currently Ability `name`  is checked to contain alpha-numeric characters and no white spaces (beside not being null nor empty).
This doesn't correspond with Telegram API requirements, which are:

> "A command must always start with the '/' symbol and may not be longer than 32 characters. Commands can use latin letters, numbers and underscores." (https://core.telegram.org/bots#commands)

This PR makes underscores allowed to use in Ability `name` and adds check for its length (requirement of leading '/' is irrelevant because Ability `name` isn't a command itself, just a "name" of a command, so to speak; however this '/' has to be taken into account, since it leaves 31 character for the rest of the command)