### PR TITLE
Fix webhook url and nullpointer

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/AbilityWebhookBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/AbilityWebhookBot.java
@@ -65,7 +65,7 @@ public abstract class AbilityWebhookBot extends BaseAbilityBot implements Webhoo
 
     @Override
     public void setWebhook(SetWebhook setWebhook) throws TelegramApiException {
-        WebhookUtils.setWebhook(this, setWebhook);
+        WebhookUtils.setWebhook(this, this.getBotPath(), setWebhook);
     }
 
     @Override

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramWebhookBot.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/TelegramWebhookBot.java
@@ -23,6 +23,6 @@ public abstract class TelegramWebhookBot extends DefaultAbsSender implements Web
 
   @Override
   public void setWebhook(SetWebhook setWebhook) throws TelegramApiException {
-    WebhookUtils.setWebhook(this, setWebhook);
+    WebhookUtils.setWebhook(this, this.getBotPath(), setWebhook);
   }
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultWebhook.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultWebhook.java
@@ -22,7 +22,7 @@ import java.net.URI;
 public class DefaultWebhook implements Webhook {
     private String keystoreServerFile;
     private String keystoreServerPwd;
-    private String internalUrl;
+    private String internalUrl = "/";
 
     private final RestApi restApi;
 

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/RestApi.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/RestApi.java
@@ -22,8 +22,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * @version 1.0
  * Rest api to for webhook callback function
  */
-@Path("callback")
+@Path(RestApi.CALLBACK)
 public class RestApi {
+
+    public static final String CALLBACK = "callback";
+
     private static final Logger log = LoggerFactory.getLogger(RestApi.class);
 
     private final ConcurrentHashMap<String, WebhookBot> callbacks = new ConcurrentHashMap<>();


### PR DESCRIPTION
When we send webhook url to telegram, we will get only server path. 
Also add default value to DefaultWebhook.internalUrl