### PR TITLE
Inject bot instance into the reply update consumer

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -625,7 +625,7 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
         return replies.stream()
                 .filter(reply -> runSilently(() -> reply.isOkFor(update), reply.name()))
                 .map(reply -> runSilently(() -> {
-                    reply.actOn(update);
+                    reply.actOn(this, update);
                     updateReplyStats(reply);
                     return false;
                 }, reply.name()))

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/DefaultAbilities.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/DefaultAbilities.java
@@ -254,7 +254,7 @@ public final class DefaultAbilities implements AbilityExtension {
         .input(0)
         .action(ctx -> bot.silent.forceReply(
             getLocalizedMessage(ABILITY_RECOVER_MESSAGE, ctx.user().getLanguageCode()), ctx.chatId()))
-        .reply(update -> {
+        .reply((bot, update) -> {
           String replyToMsg = update.getMessage().getReplyToMessage().getText();
           String recoverMessage = getLocalizedMessage(ABILITY_RECOVER_MESSAGE, AbilityUtils.getUser(update).getLanguageCode());
           if (!replyToMsg.equals(recoverMessage))

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Ability.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Ability.java
@@ -4,10 +4,12 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.telegram.abilitybots.api.bot.BaseAbilityBot;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -208,8 +210,18 @@ public final class Ability {
       return this;
     }
 
+    /**
+     * @deprecated Please use {@link #reply(BiConsumer, Predicate[])}
+     */
+    @Deprecated
     @SafeVarargs
     public final AbilityBuilder reply(Consumer<Update> action, Predicate<Update>... conditions) {
+      replies.add(Reply.of(action, conditions));
+      return this;
+    }
+
+    @SafeVarargs
+    public final AbilityBuilder reply(BiConsumer<BaseAbilityBot, Update> action, Predicate<Update>... conditions) {
       replies.add(Reply.of(action, conditions));
       return this;
     }

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/ReplyFlow.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/ReplyFlow.java
@@ -1,6 +1,7 @@
 package org.telegram.abilitybots.api.objects;
 
 import org.jetbrains.annotations.NotNull;
+import org.telegram.abilitybots.api.bot.BaseAbilityBot;
 import org.telegram.abilitybots.api.db.DBContext;
 import org.telegram.abilitybots.api.util.AbilityUtils;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -10,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -20,7 +22,7 @@ public class ReplyFlow extends Reply {
 
   private final Set<Reply> nextReplies;
 
-  private ReplyFlow(List<Predicate<Update>> conditions, Consumer<Update> action, Set<Reply> nextReplies, String name) {
+  private ReplyFlow(List<Predicate<Update>> conditions, BiConsumer<BaseAbilityBot, Update> action, Set<Reply> nextReplies, String name) {
     super(conditions, action, name);
     this.nextReplies = nextReplies;
   }
@@ -48,7 +50,7 @@ public class ReplyFlow extends Reply {
     private final DBContext db;
     private final int id;
     private List<Predicate<Update>> conds;
-    private Consumer<Update> action;
+    private BiConsumer<BaseAbilityBot, Update> action;
     private Set<Reply> nextReplies;
     private String name;
 
@@ -63,7 +65,16 @@ public class ReplyFlow extends Reply {
       this(db, replyCounter.getAndIncrement());
     }
 
+    /**
+     * @deprecated Please use {@link #action(BiConsumer)}
+     */
+    @Deprecated
     public ReplyFlowBuilder action(Consumer<Update> action) {
+      this.action = (bot, update) -> action.accept(update);
+      return this;
+    }
+
+    public ReplyFlowBuilder action(BiConsumer<BaseAbilityBot, Update> action) {
       this.action = action;
       return this;
     }
@@ -80,7 +91,7 @@ public class ReplyFlow extends Reply {
 
     public ReplyFlowBuilder next(Reply nextReply) {
       List<Predicate<Update>> statefulConditions = toStateful(nextReply.conditions());
-      Consumer<Update> statefulAction = nextReply.action().andThen(upd -> {
+      BiConsumer<BaseAbilityBot, Update> statefulAction = nextReply.action().andThen((unused, upd) -> {
         Long chatId = AbilityUtils.getChatId(upd);
         db.<Long, Integer>getMap(STATES).remove(chatId);
       });
@@ -100,16 +111,16 @@ public class ReplyFlow extends Reply {
 
     public ReplyFlow build() {
       if (action == null)
-        action = upd -> {};
+        action = (bot, upd) -> {};
 
-      Consumer<Update> statefulAction;
+      BiConsumer<BaseAbilityBot, Update> statefulAction;
       if (nextReplies.size() > 0) {
-        statefulAction = action.andThen(upd -> {
+        statefulAction = action.andThen((bot, upd) -> {
           Long chatId = AbilityUtils.getChatId(upd);
           db.<Long, Integer>getMap(STATES).put(chatId, id);
         });
       } else {
-        statefulAction = action.andThen(upd -> {
+        statefulAction = action.andThen((bot, upd) -> {
           Long chatId = AbilityUtils.getChatId(upd);
           db.<Long, Integer>getMap(STATES).remove(chatId);
         });

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
@@ -210,7 +210,7 @@ public class AbilityBotTest {
     // Support for null parameter matching since due to mocking API changes
     when(sender.downloadFile(ArgumentMatchers.<File>isNull())).thenReturn(backupFile);
 
-    defaultAbs.recoverDB().replies().get(0).actOn(update);
+    defaultAbs.recoverDB().replies().get(0).actOn(bot, update);
 
     verify(silent, times(1)).send(RECOVER_SUCCESS, GROUP_ID);
     assertEquals(db.getSet(TEST), newHashSet(TEST), "Bot recovered but the DB is still not in sync");

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/DefaultBot.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/DefaultBot.java
@@ -43,8 +43,8 @@ public class DefaultBot extends AbilityBot {
     return getDefaultBuilder()
         .name(DEFAULT)
         .info("dis iz default command")
-        .reply(Reply.of(upd -> silent.send("reply", upd.getMessage().getChatId()), MESSAGE, update -> update.getMessage().getText().equals("must reply")).enableStats("mustreply"))
-        .reply(upd -> silent.send("reply", upd.getCallbackQuery().getMessage().getChatId()), CALLBACK_QUERY)
+        .reply(Reply.of((bot, upd) -> silent.send("reply", upd.getMessage().getChatId()), MESSAGE, update -> update.getMessage().getText().equals("must reply")).enableStats("mustreply"))
+        .reply((bot, upd) -> silent.send("reply", upd.getCallbackQuery().getMessage().getChatId()), CALLBACK_QUERY)
         .build();
   }
 
@@ -75,7 +75,7 @@ public class DefaultBot extends AbilityBot {
 
   public Reply channelPostReply() {
     return Reply.of(
-        upd -> silent.send("test channel post", upd.getChannelPost().getChatId()), Flag.CHANNEL_POST
+            (bot, upd) -> silent.send("test channel post", upd.getChannelPost().getChatId()), Flag.CHANNEL_POST
     );
   }
 

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ReplyFlowTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ReplyFlowTest.java
@@ -163,19 +163,19 @@ public class ReplyFlowTest {
     }
 
     public ReplyFlow directionFlow() {
-      Reply saidLeft = Reply.of(upd -> silent.send("Sir, I have gone left.", getChatId(upd)),
+      Reply saidLeft = Reply.of((bot, upd) -> silent.send("Sir, I have gone left.", getChatId(upd)),
           hasMessageWith("go left or else"));
 
       ReplyFlow leftflow = ReplyFlow.builder(db, 2)
-          .action(upd -> silent.send("I don't know how to go left.", getChatId(upd)))
+          .action((bot, upd) -> silent.send("I don't know how to go left.", getChatId(upd)))
           .onlyIf(hasMessageWith("left"))
           .next(saidLeft).build();
 
-      Reply saidRight = Reply.of(upd -> silent.send("Sir, I have gone right.", getChatId(upd)),
+      Reply saidRight = Reply.of((bot, upd) -> silent.send("Sir, I have gone right.", getChatId(upd)),
           hasMessageWith("right"));
 
       return ReplyFlow.builder(db, 1)
-          .action(upd -> silent.send("Command me to go left or right!", getChatId(upd)))
+          .action((bot, upd) -> silent.send("Command me to go left or right!", getChatId(upd)))
           .onlyIf(hasMessageWith("wake up"))
           .next(leftflow)
           .next(saidRight)
@@ -184,10 +184,10 @@ public class ReplyFlowTest {
 
     public Reply errantReply() {
       return Reply.of(
-          upd -> {
+          (bot, upd) -> {
             throw new RuntimeException("Throwing an exception inside the update consumer");
           },
-          upd -> {
+          (upd) -> {
             throw new RuntimeException("Throwing an exception inside the reply conditions (flags)");
           });
     }
@@ -195,7 +195,7 @@ public class ReplyFlowTest {
     public Ability replyFlowsWithAbility() {
       Reply replyWithVk = ReplyFlow.builder(db, 2)
           .enableStats("SECOND")
-          .action(upd -> {
+          .action((bot, upd) -> {
             silent.send("Second reply", upd.getMessage().getChatId());
           })
           .onlyIf(hasMessageWith("two"))
@@ -203,7 +203,7 @@ public class ReplyFlowTest {
 
       Reply replyWithNickname = ReplyFlow.builder(db, 1)
           .enableStats("FIRST")
-          .action(upd -> {
+          .action((bot, upd) -> {
             silent.send("First reply", upd.getMessage().getChatId());
           })
           .onlyIf(hasMessageWith("one"))


### PR DESCRIPTION
Also added deprecated methods to still allow the old behaviour, discarding the bot reference in that case.

The condition could have a bot instance injected as well, which would require rewriting the Flag register though.