### PR TITLE
Fix Gradle 7.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ Just import add the library to your project with one of these options:
     </dependency>
 ```
 
+  2. Using Gradle: 
+
 ```gradle
-    compile "org.telegram:telegrambots:5.0.1"
+    implementation 'org.telegram:telegrambots:5.0.1'
 ```
 
-  2. Using Jitpack from [here](https://jitpack.io/#rubenlagus/TelegramBots/5.0.1)
-  3. Download the jar(including all dependencies) from [here](https://mvnrepository.com/artifact/org.telegram/telegrambots/5.0.1)
+  3. Using Jitpack from [here](https://jitpack.io/#rubenlagus/TelegramBots/5.0.1)
+  4. Download the jar(including all dependencies) from [here](https://mvnrepository.com/artifact/org.telegram/telegrambots/5.0.1)
 
 In order to use Long Polling mode, just create your own bot extending `org.telegram.telegrambots.bots.TelegramLongPollingBot`.
 

--- a/TelegramBots.wiki/Getting-Started.md
+++ b/TelegramBots.wiki/Getting-Started.md
@@ -16,8 +16,8 @@ First you need ot get the library and add it to your project. There are few poss
         ```
     * With **Gradle**:
     
-        ```groovy
-          compile group: 'org.telegram', name: 'telegrambots', version: '5.0.1'
+        ```gradle
+          implementation 'org.telegram:telegrambots:5.0.1'
         ```
  
 2. Don't like **Maven Central Repository**? It can also be taken from [Jitpack](https://jitpack.io/#rubenlagus/TelegramBots).

--- a/TelegramBots.wiki/abilities/Simple-Example.md
+++ b/TelegramBots.wiki/abilities/Simple-Example.md
@@ -13,8 +13,8 @@ As with any Java project, you will need to set your dependencies.
    </dependency>
 ```
 * **Gradle**
-```groovy
-  implementation group: 'org.telegram', name: 'telegrambots-abilities', version: '5.0.1'
+```gradle
+  implementation 'org.telegram:telegrambots-abilities:5.0.1'
 ```
 * [JitPack](https://jitpack.io/#rubenlagus/TelegramBots)
     

--- a/telegrambots-abilities/README.md
+++ b/telegrambots-abilities/README.md
@@ -25,7 +25,7 @@ Usage
 **Gradle**
 
 ```gradle
-    compile "org.telegram:telegrambots-abilities:5.0.1"
+    implementation 'org.telegram:telegrambots-abilities:5.0.1'
 ```
 
 **JitPack** - [JitPack](https://jitpack.io/#rubenlagus/TelegramBots/v5.0.1)

--- a/telegrambots-chat-session-bot/README.md
+++ b/telegrambots-chat-session-bot/README.md
@@ -19,6 +19,12 @@ Usage
     </dependency>
 ```
 
+**Gradle**
+
+```gradle
+    implementation 'org.telegram:telegrambots-chat-session-bot:5.0.1'
+```
+
 Motivation
 ----------
 Implementation of bot dialogs require saving some data about current state of conversation.

--- a/telegrambots-extensions/README.md
+++ b/telegrambots-extensions/README.md
@@ -23,5 +23,5 @@ Just import add the library to your project with one of these options:
    2. Using Gradle:
 
 ```gradle
-    compile "org.telegram:telegrambotsextensions:5.0.1"
+    implementation 'org.telegram:telegrambotsextensions:5.0.1'
 ```

--- a/telegrambots-spring-boot-starter/README.md
+++ b/telegrambots-spring-boot-starter/README.md
@@ -25,7 +25,7 @@ Usage
 **Gradle**
 
 ```gradle
-    compile "org.telegram:telegrambots-spring-boot-starter:5.0.1"
+    implementation 'org.telegram:telegrambots-spring-boot-starter:5.0.1'
 ```
 
 Motivation


### PR DESCRIPTION
The usage of `compille` configuration has been discouraged since Gradle 3.4 ([link](https://docs.gradle.org/current/userguide/upgrading_version_5.html#changes_6.0)).
And this configuration will fail with an error in Gradle 7.0. So we need to use `implementation` instead.