### PR TITLE
Fix typos

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/EditChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/EditChatInviteLink.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Builder
 public class EditChatInviteLink extends BotApiMethod<ChatInviteLink> {
-    public static final String PATH = "createChatInviteLink";
+    public static final String PATH = "editChatInviteLink";
 
     private static final String CHATID_FIELD = "chat_id";
     private static final String INVITELINK_FIELD = "invite_link";

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RevokeChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RevokeChatInviteLink.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 @AllArgsConstructor
 @Builder
 public class RevokeChatInviteLink extends BotApiMethod<ChatInviteLink> {
-    public static final String PATH = "createChatInviteLink";
+    public static final String PATH = "revokeChatInviteLink";
 
     private static final String CHATID_FIELD = "chat_id";
     private static final String INVITELINK_FIELD = "invite_link";

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
@@ -41,7 +41,7 @@ public class DefaultBotOptions implements BotOptions {
         baseUrl = ApiConstants.BASE_URL;
         httpContext = HttpClientContext.create();
         proxyType = ProxyType.NO_PROXY;
-        getUpdatesLimit = ApiConstants.GETUPDATES_TIMEOUT;
+        getUpdatesTimeout = ApiConstants.GETUPDATES_TIMEOUT;
         getUpdatesLimit = 100;
     }
 


### PR DESCRIPTION
 - Fixed PATH in `EditChatInviteLink` and `RevokeChatInviteLink`
 - Fixed `getUpdatesTimeout` not sets in `DefaultBotOptions`. This causes to use short-polling instead of long-polling.  
   See https://core.telegram.org/bots/api#getupdates:  
   > Timeout in seconds for long polling. Defaults to 0, i.e. usual short polling. Should be positive, short polling should be used for testing purposes only.