### PR TITLE
telegrambots-spring-boot-starter: add support for TelegramLongPollingCommandBot

### DIFF
--- a/telegrambots-spring-boot-starter/README.md
+++ b/telegrambots-spring-boot-starter/README.md
@@ -74,7 +74,7 @@ you don't need to register Command manual, you can write
 import org.telegram.telegrambots.starter.Annotation.TelegramCommand;
 
 @TelegramCommand(YourBotName.class)
-public class youCommand extends BotCommand {
+public class YourCommand extends BotCommand {
 
 }
 ```

--- a/telegrambots-spring-boot-starter/README.md
+++ b/telegrambots-spring-boot-starter/README.md
@@ -56,3 +56,27 @@ After that your bot will look like:
   }
 ```
 Also you could just implement LongPollingBot or WebHookBot interfaces. All this bots will be registered in context and connected to Telegram api.
+
+
+## TelegramCommandLongPolingBot compatibility
+
+```java
+//Standard Spring component annotation
+@Component
+public class YourBotName extends TelegramLongPollingCommandBot {
+    //Bot body.
+}
+```
+
+you don't need to register Command manual, you can write
+
+```java
+import org.telegram.telegrambots.starter.Annotation.TelegramCommand;
+
+@TelegramCommand(YourBotName.class)
+public class youCommand extends BotCommand {
+
+}
+```
+
+command will be registered automatically

--- a/telegrambots-spring-boot-starter/pom.xml
+++ b/telegrambots-spring-boot-starter/pom.xml
@@ -111,6 +111,12 @@
 			<version>${spring-boot.version}</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.telegram</groupId>
+            <artifactId>telegrambotsextensions</artifactId>
+            <version>5.1.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/Annotation/AfterBotRegistration.java
+++ b/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/Annotation/AfterBotRegistration.java
@@ -1,4 +1,4 @@
-package org.telegram.telegrambots.starter;
+package org.telegram.telegrambots.starter.Annotation;
 
 import org.telegram.telegrambots.meta.TelegramBotsApi;
 import org.telegram.telegrambots.meta.generics.BotSession;

--- a/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/Annotation/TelegramCommand.java
+++ b/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/Annotation/TelegramCommand.java
@@ -2,12 +2,17 @@ package org.telegram.telegrambots.starter.Annotation;
 
 import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.extensions.bots.commandbot.TelegramLongPollingCommandBot;
+import org.telegram.telegrambots.extensions.bots.commandbot.commands.BotCommand;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This annotation defines to which class of the bot will this class be registered
+ * Annotated class must extend {@link BotCommand}
+ */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Service

--- a/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/Annotation/TelegramCommand.java
+++ b/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/Annotation/TelegramCommand.java
@@ -1,0 +1,18 @@
+package org.telegram.telegrambots.starter.Annotation;
+
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.extensions.bots.commandbot.TelegramLongPollingCommandBot;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Service
+public @interface TelegramCommand {
+
+    Class<? extends TelegramLongPollingCommandBot> commandBot();
+
+}

--- a/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/TelegramBotInitializer.java
+++ b/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/TelegramBotInitializer.java
@@ -54,11 +54,10 @@ public class TelegramBotInitializer implements InitializingBean {
 
                 Class<? extends TelegramLongPollingCommandBot> bot = annotation.commandBot();
                 for (LongPollingBot longPollingBot : longPollingBots){
-                    System.out.println(longPollingBot.getClass());
-                    System.out.println(bot);
                     if (longPollingBot.getClass().equals(bot)) {
                         TelegramLongPollingCommandBot commandBot = (TelegramLongPollingCommandBot) longPollingBot;
                         commandBot.register(command);
+                        log.info(format("command \"%s\" register for bot \"%s\"", command.getClass(), bot));
                     }
                 }
             }

--- a/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/TelegramBotStarterConfiguration.java
+++ b/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/TelegramBotStarterConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.telegram.telegrambots.extensions.bots.commandbot.commands.BotCommand;
 import org.telegram.telegrambots.meta.TelegramBotsApi;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.LongPollingBot;
@@ -29,9 +30,11 @@ public class TelegramBotStarterConfiguration {
     @ConditionalOnMissingBean
     public TelegramBotInitializer telegramBotInitializer(TelegramBotsApi telegramBotsApi,
                                                          ObjectProvider<List<LongPollingBot>> longPollingBots,
-                                                         ObjectProvider<List<SpringWebhookBot>> webHookBots) {
+                                                         ObjectProvider<List<SpringWebhookBot>> webHookBots,
+                                                         ObjectProvider<List<BotCommand>> botCommands) {
         return new TelegramBotInitializer(telegramBotsApi,
                 longPollingBots.getIfAvailable(Collections::emptyList),
-                webHookBots.getIfAvailable(Collections::emptyList));
+                webHookBots.getIfAvailable(Collections::emptyList),
+                botCommands.getIfAvailable(Collections::emptyList));
     }
 }

--- a/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/MyBot.java
+++ b/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/MyBot.java
@@ -1,0 +1,21 @@
+package org.telegram.telegrambots.starter;
+
+import org.telegram.telegrambots.extensions.bots.commandbot.TelegramLongPollingCommandBot;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class MyBot extends TelegramLongPollingCommandBot {
+    @Override
+    public String getBotUsername() {
+        return null;
+    }
+
+    @Override
+    public void processNonCommandUpdate(Update update) {
+
+    }
+
+    @Override
+    public String getBotToken() {
+        return null;
+    }
+}

--- a/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/TestTelegramBotStarterConfiguration.java
+++ b/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/TestTelegramBotStarterConfiguration.java
@@ -17,7 +17,11 @@ import org.telegram.telegrambots.meta.generics.LongPollingBot;
 import org.telegram.telegrambots.starter.Annotation.TelegramCommand;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class TestTelegramBotStarterConfiguration {
 
@@ -58,7 +62,9 @@ class TestTelegramBotStarterConfiguration {
                 .run(context -> {
                     assertThat(context).hasSingleBean(TelegramLongPollingCommandBot.class);
                     assertThat(context).hasSingleBean(BotCommand.class);
+
                     TelegramLongPollingCommandBot telegramLongPollingCommandBot = context.getBean(TelegramLongPollingCommandBot.class);
+
                     verify(telegramLongPollingCommandBot, times(1)).register(context.getBean(BotCommand.class));
                     verifyNoMoreInteractions(telegramLongPollingCommandBot);
                 });
@@ -133,6 +139,16 @@ class TestTelegramBotStarterConfiguration {
     @TelegramCommand(commandBot = MyBot.class)
     static class MyBotCommand extends BotCommand{
         public MyBotCommand(String commandIdentifier, String description) {
+            super(commandIdentifier, description);
+        }
+
+        @Override
+        public void execute(AbsSender absSender, User user, Chat chat, String[] arguments) { }
+    }
+
+    @TelegramCommand(commandBot = TelegramLongPollingCommandBot.class)
+    static class OtherBotCommand extends BotCommand{
+        public OtherBotCommand(String commandIdentifier, String description) {
             super(commandIdentifier, description);
         }
 

--- a/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/TestTelegramBotStarterConfiguration.java
+++ b/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/TestTelegramBotStarterConfiguration.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.telegram.telegrambots.extensions.bots.commandbot.TelegramLongPollingCommandBot;
 import org.telegram.telegrambots.extensions.bots.commandbot.commands.BotCommand;
-import org.telegram.telegrambots.extensions.bots.commandbot.commands.CommandRegistry;
 import org.telegram.telegrambots.meta.TelegramBotsApi;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 import org.telegram.telegrambots.meta.api.objects.Chat;
@@ -18,11 +17,7 @@ import org.telegram.telegrambots.meta.generics.LongPollingBot;
 import org.telegram.telegrambots.starter.Annotation.TelegramCommand;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 class TestTelegramBotStarterConfiguration {
 

--- a/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/TestTelegramBotStarterConfiguration.java
+++ b/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/TestTelegramBotStarterConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.telegram.telegrambots.extensions.bots.commandbot.TelegramLongPollingCommandBot;
 import org.telegram.telegrambots.extensions.bots.commandbot.commands.BotCommand;
 import org.telegram.telegrambots.extensions.bots.commandbot.commands.CommandRegistry;
@@ -57,11 +58,10 @@ class TestTelegramBotStarterConfiguration {
     }
 
     @Test
-    void createTelegramLongPollingCommandBotAndBotCommand(){
-        this.contextRunner.withUserConfiguration(TelegramCommandLongPollingBot.class, TelegramCommandConfig.class, CommandRegistryMock.class)
+    void createTelegramLongPollingCommandBotAndOneBotCommand(){
+        this.contextRunner.withUserConfiguration(TelegramCommandLongPollingBot.class, TelegramCommandConfig.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(TelegramLongPollingCommandBot.class);
-                    assertThat(context).hasSingleBean(BotCommand.class);
 
                     TelegramLongPollingCommandBot telegramLongPollingCommandBot = context.getBean(TelegramLongPollingCommandBot.class);
 
@@ -131,8 +131,13 @@ class TestTelegramBotStarterConfiguration {
     @Configuration
     static class TelegramCommandConfig {
         @Bean
+        @Primary
         public MyBotCommand botCommand(){
             return new MyBotCommand("foo", "bar");
+        }
+
+        @Bean OtherBotCommand otherBotCommand(){
+            return new OtherBotCommand("foo", "bar");
         }
     }
 
@@ -154,14 +159,6 @@ class TestTelegramBotStarterConfiguration {
 
         @Override
         public void execute(AbsSender absSender, User user, Chat chat, String[] arguments) { }
-    }
-
-    @Configuration
-    static class CommandRegistryMock{
-        @Bean
-        public CommandRegistry commandRegistry(){
-            return mock(CommandRegistry.class);
-        }
     }
 
     @Configuration

--- a/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/TestTelegramBotStarterRegistrationHooks.java
+++ b/telegrambots-spring-boot-starter/src/test/java/org/telegram/telegrambots/starter/TestTelegramBotStarterRegistrationHooks.java
@@ -11,6 +11,7 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.BotSession;
 import org.telegram.telegrambots.meta.generics.LongPollingBot;
+import org.telegram.telegrambots.starter.Annotation.AfterBotRegistration;
 import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/telegrambots-spring-boot-starter/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/telegrambots-spring-boot-starter/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
automatic register BotCommand in TelegramLongPollingCommandBot

it's allow  to use ideomatic  spring DI in BotCommand classes