### PR TITLE
add TelegramLongPollingInterceptorBot

### DIFF
--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/TelegramLongPollingInterceptorBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/TelegramLongPollingInterceptorBot.java
@@ -1,0 +1,293 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot;
+
+import org.telegram.telegrambots.bots.DefaultBotOptions;
+import org.telegram.telegrambots.bots.TelegramLongPollingBot;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.IInterceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.IInterceptorsRegistry;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.InterceptorRegistry;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.PayloadStorage;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.groupadministration.SetChatPhoto;
+import org.telegram.telegrambots.meta.api.methods.send.*;
+import org.telegram.telegrambots.meta.api.methods.stickers.AddStickerToSet;
+import org.telegram.telegrambots.meta.api.methods.stickers.CreateNewStickerSet;
+import org.telegram.telegrambots.meta.api.methods.stickers.SetStickerSetThumb;
+import org.telegram.telegrambots.meta.api.methods.stickers.UploadStickerFile;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageMedia;
+import org.telegram.telegrambots.meta.api.objects.File;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.updateshandlers.SentCallback;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * <pre>
+ *     <code>
+ *         public class ExampleBOt extends TelegramLongPollingInterceptorBot{
+ *              public ExampleBOt(){
+ *                  registerInterceptor(new DurationLoggerInterceptor());
+ *              }
+ *
+ *             @Override
+ *             public void onUpdateReceived(Update update){
+ *                  User user = (User)getPayloadStorage.getPayload(User.class).getData();
+ *                  // your code
+ *             }
+ *
+ *             @Override
+ *             public String getBotUsername(){
+ *                 return "username";
+ *             }
+ *
+ *             @Override
+ *             public String getBotToken(){
+ *                 return "token";
+ *             }
+ *         }
+ *     </code>
+ * </pre>
+ * This class add ability to add interceptors
+ * @author Fedechkin Alexey aka centralhardware
+ */
+public abstract class TelegramLongPollingInterceptorBot extends TelegramLongPollingBot implements IInterceptorsRegistry {
+
+    private final IInterceptorsRegistry interceptorsRegistry = new InterceptorRegistry();
+    private final List<Object> sentMessages = new ArrayList<>();
+    private final boolean allowInterceptOutgoingObjects;
+
+    public TelegramLongPollingInterceptorBot(){
+        this(false);
+    }
+
+    public TelegramLongPollingInterceptorBot(boolean allowInterceptOutgoingObjects){
+        this(new DefaultBotOptions(), allowInterceptOutgoingObjects);
+    }
+
+    public TelegramLongPollingInterceptorBot(DefaultBotOptions options, boolean allowInterceptOutgoingObjects){
+        super(options);
+        this.allowInterceptOutgoingObjects = allowInterceptOutgoingObjects;
+    }
+
+    @Override
+    public void onUpdateReceived(Update update) {
+        if (interceptorsRegistry.callBeforeInterceptor(update, interceptorsRegistry.getPayloadStorage())) return;
+
+        onUpdateReceived(update);
+
+        if (allowInterceptOutgoingObjects) {
+            interceptorsRegistry.callAfterInterceptor(update, interceptorsRegistry.getPayloadStorage(), sentMessages);
+        } else {
+            interceptorsRegistry.callAfterInterceptor(update, interceptorsRegistry.getPayloadStorage(), null);
+        }
+        sentMessages.clear();
+    }
+
+    @Override
+    public void registerInterceptor(IInterceptor iInterceptor) {
+        interceptorsRegistry.registerInterceptor(iInterceptor);
+    }
+
+    @Override
+    public PayloadStorage getPayloadStorage() {
+        return interceptorsRegistry.getPayloadStorage();
+    }
+
+    @Override
+    public void clearStorage() {
+        this.interceptorsRegistry.clearStorage();
+    }
+
+    @Override
+    public <T extends Serializable, Method extends BotApiMethod<T>, Callback extends SentCallback<T>> void executeAsync(Method method, Callback callback) throws TelegramApiException {
+        interceptOutgoingObjects(() -> method);
+
+        super.executeAsync(method, callback);
+    }
+
+    @Override
+    public <T extends Serializable, Method extends BotApiMethod<T>> CompletableFuture<T> executeAsync(Method method) throws TelegramApiException {
+        interceptOutgoingObjects(() -> method);
+
+        return super.executeAsync(method);
+    }
+
+    @Override
+    public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) throws TelegramApiException {
+        interceptOutgoingObjects(() -> method);
+
+        return super.execute(method);
+    }
+
+    @Override
+    public Boolean execute(SetChatPhoto setChatPhoto) throws TelegramApiException {
+        interceptOutgoingObjects(() -> setChatPhoto);
+
+        return super.execute(setChatPhoto);
+    }
+
+    @Override
+    public List<Message> execute(SendMediaGroup sendMediaGroup) throws TelegramApiException {
+        interceptOutgoingObjects(() -> sendMediaGroup);
+
+        return super.execute(sendMediaGroup);
+    }
+
+    @Override
+    public Boolean execute(AddStickerToSet addStickerToSet) throws TelegramApiException {
+        interceptOutgoingObjects(() -> addStickerToSet);
+
+        return super.execute(addStickerToSet);
+    }
+
+    @Override
+    public Boolean execute(SetStickerSetThumb setStickerSetThumb) throws TelegramApiException {
+        interceptOutgoingObjects(() -> setStickerSetThumb);
+
+        return super.execute(setStickerSetThumb);
+    }
+
+    @Override
+    public Boolean execute(CreateNewStickerSet createNewStickerSet) throws TelegramApiException {
+        interceptOutgoingObjects(() -> createNewStickerSet);
+
+        return super.execute(createNewStickerSet);
+    }
+
+    @Override
+    public File execute(UploadStickerFile uploadStickerFile) throws TelegramApiException {
+        interceptOutgoingObjects(() -> uploadStickerFile);
+
+        return super.execute(uploadStickerFile);
+    }
+
+    @Override
+    public Serializable execute(EditMessageMedia editMessageMedia) throws TelegramApiException {
+        interceptOutgoingObjects(() -> editMessageMedia);
+
+        return super.execute(editMessageMedia);
+    }
+
+    @Override
+    public Message execute(SendAnimation sendAnimation) throws TelegramApiException {
+        interceptOutgoingObjects(() -> sendAnimation);
+
+        return super.execute(sendAnimation);
+    }
+
+    @Override
+    public CompletableFuture<Message> executeAsync(SendDocument sendDocument) {
+        interceptOutgoingObjects(() -> sendDocument);
+
+        return super.executeAsync(sendDocument);
+    }
+
+    @Override
+    public CompletableFuture<Message> executeAsync(SendPhoto sendPhoto) {
+        interceptOutgoingObjects(() -> sendPhoto);
+
+        return super.executeAsync(sendPhoto);
+    }
+
+    @Override
+    public CompletableFuture<Message> executeAsync(SendVideo sendVideo) {
+        interceptOutgoingObjects(() -> sendVideo);
+
+        return super.executeAsync(sendVideo);
+    }
+
+    @Override
+    public CompletableFuture<Message> executeAsync(SendVideoNote sendVideoNote) {
+        interceptOutgoingObjects(() -> sendVideoNote);
+
+        return super.executeAsync(sendVideoNote);
+    }
+
+    @Override
+    public CompletableFuture<Message> executeAsync(SendSticker sendSticker) {
+        interceptOutgoingObjects(() -> sendSticker);
+
+        return super.executeAsync(sendSticker);
+    }
+
+    @Override
+    public CompletableFuture<Message> executeAsync(SendAudio sendAudio) {
+        interceptOutgoingObjects(() -> sendAudio);
+
+        return super.executeAsync(sendAudio);
+    }
+
+    @Override
+    public CompletableFuture<Message> executeAsync(SendVoice sendVoice) {
+        interceptOutgoingObjects(() -> sendVoice);
+
+        return super.executeAsync(sendVoice);
+    }
+
+    @Override
+    public CompletableFuture<List<Message>> executeAsync(SendMediaGroup sendMediaGroup) {
+        interceptOutgoingObjects(() -> sendMediaGroup);
+
+        return super.executeAsync(sendMediaGroup);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> executeAsync(SetChatPhoto setChatPhoto) {
+        interceptOutgoingObjects(() -> setChatPhoto);
+
+        return super.executeAsync(setChatPhoto);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> executeAsync(AddStickerToSet addStickerToSet) {
+        interceptOutgoingObjects(() -> addStickerToSet);
+
+        return super.executeAsync(addStickerToSet);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> executeAsync(SetStickerSetThumb setStickerSetThumb) {
+        interceptOutgoingObjects(() -> setStickerSetThumb);
+
+        return super.executeAsync(setStickerSetThumb);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> executeAsync(CreateNewStickerSet createNewStickerSet) {
+        interceptOutgoingObjects(() -> createNewStickerSet);
+
+        return super.executeAsync(createNewStickerSet);
+    }
+
+    @Override
+    public CompletableFuture<File> executeAsync(UploadStickerFile uploadStickerFile) {
+        interceptOutgoingObjects(() -> uploadStickerFile);
+
+        return super.executeAsync(uploadStickerFile);
+    }
+
+    @Override
+    public CompletableFuture<Serializable> executeAsync(EditMessageMedia editMessageMedia) {
+        interceptOutgoingObjects(() -> editMessageMedia);
+
+        return super.executeAsync(editMessageMedia);
+    }
+
+    @Override
+    public CompletableFuture<Message> executeAsync(SendAnimation sendAnimation) {
+        interceptOutgoingObjects(() -> sendAnimation);
+
+        return super.executeAsync(sendAnimation);
+    }
+
+    private void interceptOutgoingObjects(Supplier<Object> supplier){
+        if (!allowInterceptOutgoingObjects) return;
+
+        sentMessages.add(supplier.get());
+    }
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/FeatureDisable.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/FeatureDisable.java
@@ -1,0 +1,7 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+/**
+ * Thrown if anyone try to call {@link Interceptor#getSendMessages(Class)} but saving sent objects did not enabled
+ */
+public class FeatureDisable extends RuntimeException {
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/IInterceptor.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/IInterceptor.java
@@ -1,0 +1,42 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.generics.LongPollingBot;
+
+import java.util.List;
+
+/**
+ *
+ */
+public interface IInterceptor {
+
+    /**
+     * indicates that interceptor chain must be continue
+     */
+    boolean INTERRUPT   = true;
+    /**
+     * indicates that interceptor chain must be interrupt
+     */
+    boolean PROCESS     = false;
+
+    /**
+     * method that will be call before after {@link LongPollingBot#onUpdateReceived(Update)}
+     * @param update  update redirected from {@link LongPollingBot#onUpdateReceived(Update)} params
+     * @param storage payloads storage for current bot
+     */
+    boolean before(Update update, PayloadStorage storage);
+
+    /**
+     * method that will be call after {@link LongPollingBot#onUpdateReceived(Update)}
+     * @param update update redirected from {@link LongPollingBot#onUpdateReceived(Update)} params
+     * @param storage payloads storage for current bot
+     */
+    void after(Update update, PayloadStorage storage);
+
+    /**
+     * set current sent objects
+     * @param messages null if feature not enabled
+     */
+    void setSentMessages(List<Object> messages);
+
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/IInterceptorsRegistry.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/IInterceptorsRegistry.java
@@ -1,0 +1,43 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.generics.LongPollingBot;
+
+import java.util.List;
+
+/**
+ * registry for manage interceptor chain
+ */
+public interface IInterceptorsRegistry {
+
+    /**
+     * add interceptor for chain
+     * @param iInterceptor interceptor for register
+     */
+    void registerInterceptor(IInterceptor iInterceptor);
+
+    /**
+     * @param update update redirected from {@link LongPollingBot#onUpdateReceived(Update)} params
+     * @param storage payloads storage for current bot
+     * @return true if chain must be continue
+     */
+    boolean callBeforeInterceptor(Update update, PayloadStorage storage);
+
+    /**
+     * @param update update redirected from {@link LongPollingBot#onUpdateReceived(Update)} params
+     * @param storage payloads storage for current bot
+     * @param sentMessages list of saving outgoing messages
+     */
+    void callAfterInterceptor(Update update, PayloadStorage storage, List<Object> sentMessages);
+
+    /**
+     * @return instance of {@link PayloadStorage} for current bot
+     */
+    PayloadStorage getPayloadStorage();
+
+    /**
+     * delete all payloads
+     */
+    void clearStorage();
+
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/Interceptor.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/Interceptor.java
@@ -1,0 +1,93 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations.ContentTypeFilterInterceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations.DurationLoggerInterceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations.RegexFilterInterceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations.UserExtractInterceptor;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * default methods implementation
+ *
+ * example:
+ * <pre>
+ *     <code>
+ *         // UserExtractInterceptor required
+ *         public class ExampleInterceptor extend Interceptor{
+ *              @Override
+ *              public boolean before(Update update, PayloadStorage storage){
+ *                  User user = (User)storage.getPayload(User.class).getData();
+ *                  if (user.getUserName().equals("alice")) return interrupt();
+ *
+ *                  return process();
+ *              }
+ *         }
+ *     </code>
+ * </pre>
+ *
+ * see build in interceptor implementations
+ * @see ContentTypeFilterInterceptor
+ * @see DurationLoggerInterceptor
+ * @see RegexFilterInterceptor
+ * @see UserExtractInterceptor
+ */
+public abstract class Interceptor implements IInterceptor {
+
+    private List<Object> sentMessages;
+
+    /**
+     * @return {@link IInterceptor#INTERRUPT}
+     */
+    public final boolean interrupt(){
+        return INTERRUPT;
+    }
+
+    /**
+     * @return {@link IInterceptor#PROCESS}
+     */
+    public final boolean process(){
+        return PROCESS;
+    }
+
+    public boolean before(Update update, PayloadStorage storage){
+        return process();
+    }
+
+    public void after(Update update, PayloadStorage storage){ }
+
+    @Override
+    public final void setSentMessages(List<Object> messages) {
+        this.sentMessages = messages;
+    }
+
+
+    /**
+     * @param clazz the class of all instances to get
+     * @param <T> must be extend {@link PartialBotApiMethod} or {@link BotApiMethod}
+     * @throws FeatureDisable if saving sent feature not enabled
+     * @return list of sent objects of a given class
+     */
+    public final <T> List<T> getSendMessages(Class<T> clazz){
+        checkFeatureEnable();
+
+        if (BotApiMethod.class.isAssignableFrom(clazz) || PartialBotApiMethod.class.isAssignableFrom(clazz)) {
+            //noinspection unchecked
+            return sentMessages.
+                    stream().
+                    filter(it -> it.getClass() == clazz).
+                    map(it -> (T) it).
+                    collect(Collectors.toList());
+        }
+        throw new IllegalArgumentException(String.format("class %s is not api methods class " +
+                "(not extend BotApiMethod.class or PartialBotApiMethod.class)", clazz));
+    }
+
+    public final void checkFeatureEnable(){
+        if (sentMessages == null) throw new FeatureDisable();
+    }
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/InterceptorRegistry.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/InterceptorRegistry.java
@@ -60,8 +60,8 @@ public class InterceptorRegistry implements IInterceptorsRegistry {
         return interceptors.
                 stream().
                 filter(it -> it.getClass().getAnnotation(First.class) != null).
-                filter(it -> it.getClass().getAnnotation(First.class).stage() == stage).
-                filter(it -> it.getClass().getAnnotation(First.class).stage() == Stage.BOTH).
+                filter(it -> it.getClass().getAnnotation(First.class).stage() == stage ||
+                        it.getClass().getAnnotation(First.class).stage() == Stage.BOTH).
                 collect(Collectors.toList());
     }
 
@@ -69,8 +69,8 @@ public class InterceptorRegistry implements IInterceptorsRegistry {
         return interceptors.
                 stream().
                 filter(it -> it.getClass().getAnnotation(Last.class) != null).
-                filter(it -> it.getClass().getAnnotation(Last.class).stage() == stage).
-                filter(it -> it.getClass().getAnnotation(Last.class).stage() == Stage.BOTH).
+                filter(it -> it.getClass().getAnnotation(Last.class).stage() == stage ||
+                        it.getClass().getAnnotation(Last.class).stage() == Stage.BOTH).
                 collect(Collectors.toList());
     }
 

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/InterceptorRegistry.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/InterceptorRegistry.java
@@ -1,0 +1,86 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations.First;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations.Last;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class InterceptorRegistry implements IInterceptorsRegistry {
+
+    private final List<IInterceptor> interceptors = new ArrayList<>();
+    private final PayloadStorage payloadStorage = new PayloadStorage();
+
+    @Override
+    public void registerInterceptor(IInterceptor iInterceptor) {
+        interceptors.add(iInterceptor);
+    }
+
+    @Override
+    public boolean callBeforeInterceptor(Update update, PayloadStorage storage) {
+        for (IInterceptor interceptor : getFirstAnnotatedInterceptor(Stage.BEFORE)){
+            if (interceptor.before(update, storage)) return true;
+        }
+        for (IInterceptor interceptor : getInterceptorWithoutAnnotation()) {
+            if (interceptor.before(update, storage)) return true;
+        }
+        for (IInterceptor interceptor : getLastAnnotation(Stage.BEFORE)){
+            if (interceptor.before(update, storage)) return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void callAfterInterceptor(Update update, PayloadStorage storage, List<Object> sentMessages) {
+        for (IInterceptor interceptor : getFirstAnnotatedInterceptor(Stage.AFTER)){
+            interceptor.setSentMessages(sentMessages);
+            interceptor.after(update, storage);
+        }
+        for (IInterceptor interceptor : getInterceptorWithoutAnnotation()){
+            interceptor.setSentMessages(sentMessages);
+            interceptor.after(update, storage);
+        }
+        for (IInterceptor interceptor : getLastAnnotation(Stage.AFTER)){
+            interceptor.setSentMessages(sentMessages);
+            interceptor.after(update, storage);
+        }
+    }
+
+    public List<IInterceptor> getInterceptorWithoutAnnotation(){
+        return interceptors.stream().
+                filter(it -> it.getClass().getAnnotation(First.class) == null).
+                filter(it -> it.getClass().getAnnotation(Last.class) == null).
+                collect(Collectors.toList());
+    }
+
+    public List<IInterceptor> getFirstAnnotatedInterceptor(Stage stage){
+        return interceptors.
+                stream().
+                filter(it -> it.getClass().getAnnotation(First.class) != null).
+                filter(it -> it.getClass().getAnnotation(First.class).stage() == stage).
+                filter(it -> it.getClass().getAnnotation(First.class).stage() == Stage.BOTH).
+                collect(Collectors.toList());
+    }
+
+    public List<IInterceptor> getLastAnnotation(Stage stage){
+        return interceptors.
+                stream().
+                filter(it -> it.getClass().getAnnotation(Last.class) != null).
+                filter(it -> it.getClass().getAnnotation(Last.class).stage() == stage).
+                filter(it -> it.getClass().getAnnotation(Last.class).stage() == Stage.BOTH).
+                collect(Collectors.toList());
+    }
+
+    @Override
+    public PayloadStorage getPayloadStorage() {
+        return payloadStorage;
+    }
+
+    @Override
+    public void clearStorage() {
+        payloadStorage.clearStorage();
+    }
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/Payload.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/Payload.java
@@ -1,0 +1,25 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+/**
+ * immutable payload holder
+ * @param <T>
+ */
+public class Payload<T> {
+
+    private final T data;
+
+    private Payload(T data) {
+        this.data = data;
+    }
+
+    public T getData(){
+        return data;
+    }
+
+    public static <T> Payload<T> of(T data){
+        if (data == null) throw new IllegalArgumentException();
+
+        return new Payload<>(data);
+    }
+
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/PayloadStorage.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/PayloadStorage.java
@@ -1,0 +1,39 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PayloadStorage {
+
+    private final Map<Class<?>, Payload<?>> payloads = new HashMap<>();
+
+    /**
+     * @param clazz payload data class using for identify payload
+     * @param payload instance of payload with data
+     */
+    public void addPayload(Class<?> clazz, Payload<?> payload){
+        if (payload.getData().getClass() != clazz) throw new IllegalArgumentException();
+
+        payloads.put(clazz, payload);
+    }
+
+    /**
+     * @param clazz identifier of payload
+     * @return objects from payload by giving class
+     */
+    public Payload<?> getPayload(Class<?> clazz){
+        return payloads.get(clazz);
+    }
+
+    public int getPayloadSize(){
+        return payloads.size();
+    }
+
+    /**
+     * delete all payloads
+     */
+    public void clearStorage(){
+        payloads.clear();
+    }
+
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/Stage.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/Stage.java
@@ -1,0 +1,7 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+public enum Stage {
+    BEFORE,
+    AFTER,
+    BOTH
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/annotations/First.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/annotations/First.java
@@ -1,0 +1,23 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Stage;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * indicate that interceptor must execute firstly
+ * if more one interceptor annotated order not defined
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface First {
+
+    /**
+     * specifies to apply the given annotation to the method before or after
+     */
+    Stage stage();
+
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/annotations/Last.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/annotations/Last.java
@@ -1,0 +1,23 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Stage;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * indicate that interceptor must execute lastly
+ * if more one interceptor annotated order not defined
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Last {
+
+    /**
+     * specifies to apply the given annotation to the method before or after
+     */
+    Stage stage();
+
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/ContentTypeFilterInterceptor.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/ContentTypeFilterInterceptor.java
@@ -1,0 +1,59 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Interceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.PayloadStorage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.List;
+
+/**
+ * an interceptor that filters incoming updates based on the allowed container types
+ */
+public class ContentTypeFilterInterceptor extends Interceptor {
+
+    private final List<ContentType> allowedContentType;
+
+    /**
+     * @param allowedContentType List of content type updates with which will be allowed.
+     *                           if the update does not contain any of the specified types, it will be filtered
+     */
+    public ContentTypeFilterInterceptor(List<ContentType> allowedContentType){
+        this.allowedContentType = allowedContentType;
+    }
+
+    @Override
+    public boolean before(Update update, PayloadStorage storage) {
+        for (ContentType type : allowedContentType){
+            switch (type){
+                case MESSAGE:               if (update.hasMessage())            return process();
+                case INLINE_QUERY:          if (update.hasInlineQuery())        return process();
+                case CHOOSE_INLINE_QUERY:   if (update.hasChosenInlineQuery())  return process();
+                case CALLBACK_QUERY:        if (update.hasCallbackQuery())      return process();
+                case EDIT_MESSAGE:          if (update.hasEditedMessage())      return process();
+                case EDIT_CHANNEL_POST:     if (update.hasEditedChannelPost())  return process();
+                case SHIPPING_QUERY:        if (update.hasShippingQuery())      return process();
+                case PRE_CHECKOUT_QUERY:    if (update.hasPreCheckoutQuery())   return process();
+                case MY_CHAT_MEMBER:        if (update.hasMyChatMember())       return process();
+                case CHAT_MEMBER:           if (update.hasChatMember())         return process();
+            }
+        }
+
+        return interrupt();
+    }
+
+    /**
+     * Enumeration of {@link Update} types of content
+     */
+    public enum ContentType{
+        MESSAGE,
+        INLINE_QUERY,
+        CHOOSE_INLINE_QUERY,
+        CALLBACK_QUERY,
+        EDIT_MESSAGE,
+        EDIT_CHANNEL_POST,
+        SHIPPING_QUERY,
+        PRE_CHECKOUT_QUERY,
+        MY_CHAT_MEMBER,
+        CHAT_MEMBER
+    }
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/DurationLoggerInterceptor.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/DurationLoggerInterceptor.java
@@ -1,0 +1,51 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Interceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.PayloadStorage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.sql.Timestamp;
+import java.util.function.BiConsumer;
+
+/**
+ * interceptor that logs the beginning, the end and the duration of the update processing
+ */
+public class DurationLoggerInterceptor extends Interceptor {
+    private static final Logger log = LoggerFactory.getLogger(DurationLoggerInterceptor.class);
+
+    private BiConsumer<Integer, Long> consumer = null;
+    private Timestamp startTime;
+
+    /**
+     * create interceptor without consumer
+     */
+    public DurationLoggerInterceptor() { }
+
+    /**
+     * @param consumer lambda to which the request time will and update id be sent
+     */
+    public DurationLoggerInterceptor(BiConsumer<Integer, Long> consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public boolean before(Update update, PayloadStorage storage) {
+        log.info("process update {} started", update.getUpdateId());
+        startTime = new Timestamp(System.currentTimeMillis());
+
+        return process();
+    }
+
+    @Override
+    public void after(Update update, PayloadStorage storage) {
+        Timestamp endTime = new Timestamp(System.currentTimeMillis());
+        long spendTime = endTime.getTime() - startTime.getTime();
+
+        log.info("process update {} ended. time spent {}", update.getUpdateId(), spendTime);
+        if (consumer == null) return;
+
+        consumer.accept(update.getUpdateId(), spendTime);
+    }
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/GenericAfterInterceptor.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/GenericAfterInterceptor.java
@@ -1,0 +1,31 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Interceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.PayloadStorage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.concurrent.Callable;
+
+/**
+ * an interceptor that execute callable after processing update
+ */
+public class GenericAfterInterceptor extends Interceptor {
+    private static final Logger log = LoggerFactory.getLogger(GenericAfterInterceptor.class);
+
+    private final Callable callable;
+
+    public GenericAfterInterceptor(Callable callable) {
+        this.callable = callable;
+    }
+
+    @Override
+    public void after(Update update, PayloadStorage storage) {
+        try {
+            callable.call();
+        } catch (Exception e) {
+            log.warn("", e);
+        }
+    }
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/GenericBeforeInterceptor.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/GenericBeforeInterceptor.java
@@ -1,0 +1,37 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Interceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.PayloadStorage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.concurrent.Callable;
+
+/**
+ * an interceptor that execute callable before processing update
+ */
+public class GenericBeforeInterceptor extends Interceptor {
+    private static final Logger log = LoggerFactory.getLogger(GenericBeforeInterceptor.class);
+
+    private final Callable callable;
+
+    public GenericBeforeInterceptor(Callable callable) {
+        this.callable = callable;
+    }
+
+    /**
+     * @return {@link Interceptor#INTERRUPT} if {@link Callable#call()} throw some exception
+     */
+    @Override
+    public boolean before(Update update, PayloadStorage storage) {
+        try {
+            callable.call();
+        } catch (Exception e) {
+            log.warn("", e);
+            return interrupt();
+        }
+
+        return process();
+    }
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/RegexFilterInterceptor.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/RegexFilterInterceptor.java
@@ -1,0 +1,31 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Interceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.PayloadStorage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * an interceptor that filters text updates based on regular regex, if regex don't match text update interrupt
+ */
+public class RegexFilterInterceptor extends Interceptor {
+
+    private final String regex;
+
+    /**
+     * @param regex regular expression
+     */
+    public RegexFilterInterceptor(String regex) {
+        this.regex = regex;
+    }
+
+    @Override
+    public boolean before(Update update, PayloadStorage storage) {
+        if (!(update.hasMessage() && update.getMessage().hasText())) return interrupt();
+
+        if (!update.getMessage().getText().matches(regex)){
+            return interrupt();
+        }
+
+        return process();
+    }
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/UserExtractInterceptor.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/implementations/UserExtractInterceptor.java
@@ -1,0 +1,45 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.implementations;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Interceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Payload;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.PayloadStorage;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Stage;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations.First;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+/**
+ * an interceptor that extracts the user object from the update and stores it in PayloadStorage
+ */
+@First(stage = Stage.BEFORE)
+public class UserExtractInterceptor extends Interceptor {
+
+    @Override
+    public boolean before(Update update, PayloadStorage storage) {
+        User user = null;
+        if (update.hasMessage()){
+            user = update.getMessage().getFrom();
+        } else if (update.hasInlineQuery()){
+            user = update.getInlineQuery().getFrom();
+        } else if (update.hasChosenInlineQuery()){
+            user = update.getChosenInlineQuery().getFrom();
+        } else if (update.hasCallbackQuery()){
+            user = update.getCallbackQuery().getFrom();
+        } else if (update.hasEditedMessage()){
+            user = update.getEditedMessage().getFrom();
+        } else if (update.hasEditedChannelPost()){
+            user = update.getEditedChannelPost().getFrom();
+        } else if (update.hasShippingQuery()){
+            user = update.getShippingQuery().getFrom();
+        } else if (update.hasPreCheckoutQuery()){
+            user = update.getPreCheckoutQuery().getFrom();
+        } else if (update.hasMyChatMember()){
+            user = update.getMyChatMember().getFrom();
+        } else if (update.hasChatMember()){
+            user = update.getChatMember().getFrom();
+        }
+        storage.addPayload(User.class, Payload.of(user));
+
+        return process();
+    }
+}

--- a/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/AInterceptorRegistryTest.java
+++ b/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/AInterceptorRegistryTest.java
@@ -1,0 +1,71 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.support.AInterceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.support.BInterceptor;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AInterceptorRegistryTest {
+
+    private final static Update UPDATE             = null;
+    private final static PayloadStorage STORAGE    = null;
+
+    @Test
+    public void shouldCallBeforeAndAfterInterceptor(){
+        InterceptorRegistry registry = new InterceptorRegistry();
+
+        Interceptor aInterceptor = Mockito.mock(AInterceptor.class);
+        Interceptor bInterceptor = Mockito.mock(BInterceptor.class);
+        Interceptor cInterceptor = Mockito.mock(Interceptor.class);
+        Interceptor dInterceptor = Mockito.mock(Interceptor.class);
+
+        registry.registerInterceptor(aInterceptor);
+        registry.registerInterceptor(bInterceptor);
+        registry.registerInterceptor(cInterceptor);
+        registry.registerInterceptor(dInterceptor);
+
+        assertEquals(registry.getFirstAnnotatedInterceptor(Stage.BEFORE).size(), 1);
+        assertEquals(registry.getFirstAnnotatedInterceptor(Stage.AFTER).size(), 1);
+        assertEquals(registry.getLastAnnotation(Stage.BEFORE).size(), 1);
+        assertEquals(registry.getLastAnnotation(Stage.AFTER).size(), 1);
+
+        when(aInterceptor.before(UPDATE, STORAGE)).thenReturn(false);
+        when(bInterceptor.before(UPDATE, STORAGE)).thenReturn(false);
+        when(cInterceptor.before(UPDATE, STORAGE)).thenReturn(false);
+        when(dInterceptor.before(UPDATE, STORAGE)).thenReturn(false);
+
+        InOrder order = inOrder(aInterceptor, bInterceptor);
+
+        assertFalse(registry.callBeforeInterceptor(UPDATE, STORAGE));
+
+        order.verify(aInterceptor).before(UPDATE, STORAGE);
+        order.verify(bInterceptor).before(UPDATE, STORAGE);
+
+        verify(cInterceptor).before(UPDATE, STORAGE);
+        verify(dInterceptor).before(UPDATE, STORAGE);
+
+        doNothing().when(aInterceptor).after(UPDATE, STORAGE);
+        doNothing().when(bInterceptor).after(UPDATE, STORAGE);
+        doNothing().when(cInterceptor).after(UPDATE, STORAGE);
+        doNothing().when(dInterceptor).after(UPDATE, STORAGE);
+
+        order = inOrder(bInterceptor, aInterceptor);
+
+        registry.callAfterInterceptor(UPDATE, STORAGE, new ArrayList<>());
+
+        order.verify(bInterceptor).after(UPDATE, STORAGE);
+        order.verify(aInterceptor).after(UPDATE, STORAGE);
+
+        verify(cInterceptor).after(UPDATE, STORAGE);
+        verify(dInterceptor).after(UPDATE, STORAGE);
+    }
+
+
+}

--- a/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/InterceptorTest.java
+++ b/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/InterceptorTest.java
@@ -1,0 +1,49 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.send.SendAnimation;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.send.SendSticker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InterceptorTest {
+
+    private Interceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new Interceptor() {};
+    }
+
+    private List<Object> savingObjects;
+
+    @Test
+    void getSendMessages() {
+        List<Object> savingObjects = new ArrayList<>();
+        savingObjects.add(new SendMessage());
+        savingObjects.add(new SendSticker());
+        savingObjects.add(new SendAnimation());
+        interceptor.setSentMessages(savingObjects);
+
+        assertEquals(1, interceptor.getSendMessages(SendMessage.class).size());
+        assertEquals(1, interceptor.getSendMessages(SendSticker.class).size());
+
+        interceptor.setSentMessages(new ArrayList<>());
+
+        assertDoesNotThrow(() -> interceptor.getSendMessages(SendMessage.class));
+
+        assertThrows(IllegalArgumentException.class, () -> interceptor.getSendMessages(InterceptorTest.class));
+    }
+
+    @Test
+    void checkFeatureEnable() {
+        interceptor.setSentMessages(null);
+
+        assertThrows(FeatureDisable.class, () -> interceptor.getSendMessages(SendMessage.class));
+    }
+}

--- a/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/PayloadStorageTest.java
+++ b/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/PayloadStorageTest.java
@@ -1,0 +1,25 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PayloadStorageTest {
+
+    private final Payload<Integer> testPayload = Payload.of(41);
+    private final PayloadStorage storage = new PayloadStorage();
+
+    @Test
+    void addPayload() {
+        storage.addPayload(Integer.class, testPayload);
+        assertEquals(storage.getPayload(Integer.class).getData(), 41);
+        assertTrue(storage.getPayload(Integer.class).getData() instanceof Integer);
+    }
+
+    @Test
+    void clearStorage() {
+        storage.addPayload(Integer.class, testPayload);
+        storage.clearStorage();
+        assertEquals(0, storage.getPayloadSize());
+    }
+}

--- a/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/PayloadTest.java
+++ b/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/PayloadTest.java
@@ -1,0 +1,14 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PayloadTest {
+
+    @Test
+    void of() {
+        assertThrows(IllegalArgumentException.class, () -> Payload.of(null));
+        assertDoesNotThrow(() -> Payload.of(41));
+    }
+}

--- a/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/support/AInterceptor.java
+++ b/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/support/AInterceptor.java
@@ -1,0 +1,10 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.support;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Interceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Stage;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations.First;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations.Last;
+
+@First(stage = Stage.BEFORE)
+@Last(stage = Stage.AFTER)
+public class AInterceptor extends Interceptor { }

--- a/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/support/BInterceptor.java
+++ b/telegrambots-extensions/src/test/java/org/telegram/telegrambots/extensions/bots/intreceptorbot/intreceptors/support/BInterceptor.java
@@ -1,0 +1,10 @@
+package org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.support;
+
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Interceptor;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.Stage;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations.First;
+import org.telegram.telegrambots.extensions.bots.intreceptorbot.intreceptors.annotations.Last;
+
+@First(stage = Stage.AFTER)
+@Last(stage = Stage.BEFORE)
+public class BInterceptor extends Interceptor { }

--- a/telegrambots-extensions/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/telegrambots-extensions/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
PR add TelegramLongPollingInterceptorBot which allows to add interceptors (who can run before or after) 
it's allow to divide logic into separate parts that can be executed in isolation one after another.

Motivation:

onUpdateReceived contains a lot of code that not directly related to the bot's logic. like:

- getting any data (this takes up a lot of space, since we do not know in advance what kind of data will come in the update)
- loging
- delegating case handling to other classes and methods
- hend edge cases

all this moment can be resolved by placing the code associated with these things in separate interceptors

interceptor can be used for:

- filtering updates
- do something logic like logging 
- extract some required data like user or chat id (saved in PayloadStorage)

TelegramLongPollingInterceptorBot support two type interceptor:

- before interceptor: execute before call onUpdateReceived methods in telegram bot class. before interceptor can interrupt processing incoming update
- after interceptor: can only execute some code, if allowInterceptOutgoingObjects set to true, after interceptor can access all objects which sent by AbsSender

interceptor can be call:

- first
- last

if specified more then one specify first or last priority order not defined

priority is needed to interceptor can use some data from PayloadStorage, it is necessary that these interceptors are called after the intreceptors that perform data extraction

build in interceptor implementations:

- ContentTypeFilterInterceptor (before) - allow to receive updates only specified types 
- DurationLoggerInterceptor (before and after) - allow to getting update processing duration to the standart log and custom consumer
- RegexFilterInterceptor (before) - allow only text messages that match regex
- UserExtractInterceptor (before) - allow to get current User instance, you no longer need to know what kind of content is contained in the update for this.
- GenericBeforeInterceptor - execute callable before processing update 
- GenericAfterInterceptor -  execute callable after processing update

can be implemented with interceptor:

- loggin
- extract chat id
- load User from database asociated with current telegram user
- checking that user have required permissions
- collect statistic
- you can implement interceptor that will be enabled only in dev and perform some debug logic 