### PR TITLE
Modify DefaultAbsSender.java for issue #494

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -150,7 +150,7 @@ public abstract class DefaultAbsSender extends AbsSender {
     public void Async_execute(SendPhoto sendPhoto){
         executor.submit(()->{
             try{
-                new Thread (String.valueOf(execute(sendPhoto)));
+                execute(sendPhoto);
             }catch (Exception e){
                 e.printStackTrace();
             }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -74,6 +74,8 @@ public abstract class DefaultAbsSender extends AbsSender {
     private final RequestConfig requestConfig;
     private final TelegramFileDownloader telegramFileDownloader;
 
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
     protected DefaultAbsSender(DefaultBotOptions options) {
         super();
 
@@ -141,6 +143,18 @@ public abstract class DefaultAbsSender extends AbsSender {
 
     public final InputStream downloadFileAsStream(File file) throws TelegramApiException {
         return telegramFileDownloader.downloadFileAsStream(file);
+    }
+
+    // sendXXXXAsync method use ThreadPoolExecutor
+
+    public void Async_execute(SendPhoto sendPhoto){
+        executor.submit(()->{
+            try{
+                new Thread (String.valueOf(execute(sendPhoto)));
+            }catch (Exception e){
+                e.printStackTrace();
+            }
+        });
     }
 
     // Specific Send Requests


### PR DESCRIPTION
#494 
I try to use the ThreadPool (**newCachedThreadPool**) to excute the sendphoto Async.
And it has a good performance , which can be seen in this url:
https://github.com/genjiezio/ImageRepository/blob/main/BSY8UISCOQD752OGHMO91MF.png