### PR TITLE
Add new Feature "isConnectFine" in DefaultBotSession.java linked to Issue #299

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
@@ -276,7 +276,7 @@ public class DefaultBotSession implements BotSession {
                 NumberOfContinuousInterError = 0;
             } catch (InvalidObjectException | TelegramApiRequestException e) {
                 log.error(e.getLocalizedMessage(), e);
-            } catch (SocketException | SocketTimeoutException | UnknownHostException e) {
+            } catch (SocketException | SocketTimeoutException) {
                 log.info(e.getLocalizedMessage(), e);
                 NumberOfContinuousNetworkError++;
             } catch (InterruptedException e) {

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
@@ -276,7 +276,7 @@ public class DefaultBotSession implements BotSession {
                 NumberOfContinuousInterError = 0;
             } catch (InvalidObjectException | TelegramApiRequestException e) {
                 log.error(e.getLocalizedMessage(), e);
-            } catch (SocketException | SocketTimeoutException) {
+            } catch (SocketException | SocketTimeoutException e) {
                 log.info(e.getLocalizedMessage(), e);
                 NumberOfContinuousNetworkError++;
             } catch (InterruptedException e) {

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/TestDefaultBotSession.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/TestDefaultBotSession.java
@@ -155,7 +155,15 @@ public class TestDefaultBotSession {
         DefaultBotSession session = new DefaultBotSession();
         session.setOptions(options);
     }
-
+    
+    @Test
+    public void testDefaultBotSessionIsConnectFine() throws IOException {
+        session = getDefaultBotSession();
+        session.start();
+        Assert.assertFalse(session.isConnectFine());
+        session.stop();
+    }
+    
     @Test
     public void testDefaultBotSessionWithCustomConstantBackOff() {
         DefaultBotOptions options = new DefaultBotOptions();


### PR DESCRIPTION
A new mothod **isConnectFine** was added. Which just gives a judgement about connection status according to the number of Continuous Exception, and doesn't set **running** to false directly. #299 