### PR TITLE
Add an access to the user in ChatMember interface

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -265,10 +265,10 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
                 .orElse(new ArrayList<>())
                 .stream()
                 .map(member -> {
-                    if (member instanceof ChatMemberAdministrator) {
-                        return ((ChatMemberAdministrator) member).getUser().getId();
-                    } else if (member instanceof ChatMemberOwner) {
-                        return ((ChatMemberOwner) member).getUser().getId();
+                    final String status = member.getStatus();
+                    if (status.equals(ChatMemberOwner.STATUS)
+                            || status.equals(ChatMemberAdministrator.STATUS)) {
+                        return member.getUser().getId();
                     }
                     return 0L;
                 })

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
@@ -26,6 +26,7 @@ import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
 import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMemberAdministrator;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
@@ -453,8 +454,8 @@ public class AbilityBotTest {
     mockUser(update, message, user);
     when(message.isGroupMessage()).thenReturn(true);
 
-    ChatMemberAdministrator member = mock(ChatMemberAdministrator.class);
-    when(member.getUser()).thenReturn(user);
+    ChatMember member = mock(ChatMember.class);
+    when(member.getStatus()).thenReturn(ChatMemberAdministrator.STATUS);
     when(member.getUser()).thenReturn(user);
 
     when(silent.execute(any(GetChatAdministrators.class))).thenReturn(Optional.of(newArrayList(member)));

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMember.java
@@ -2,6 +2,7 @@ package org.telegram.telegrambots.meta.api.objects.chatmember;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.User;
 import org.telegram.telegrambots.meta.api.objects.chatmember.serialization.ChatMemberDeserializer;
 
 /**
@@ -14,4 +15,5 @@ import org.telegram.telegrambots.meta.api.objects.chatmember.serialization.ChatM
 @JsonDeserialize(using = ChatMemberDeserializer.class)
 public interface ChatMember extends BotApiObject {
     String getStatus();
+    User getUser();
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberAdministrator.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberAdministrator.java
@@ -26,6 +26,8 @@ import org.telegram.telegrambots.meta.api.objects.User;
 @AllArgsConstructor
 @Builder
 public class ChatMemberAdministrator implements ChatMember {
+    public static final String STATUS = "administrator";
+
     private static final String STATUS_FIELD = "status";
     private static final String USER_FIELD = "user";
     private static final String CANBEEDITED_FIELD = "can_be_edited";
@@ -46,7 +48,7 @@ public class ChatMemberAdministrator implements ChatMember {
      * The member's status in the chat, always “administrator”
      */
     @JsonProperty(STATUS_FIELD)
-    private final String status = "administrator";
+    private final String status = STATUS;
     /**
      * Information about the user
      */

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberBanned.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberBanned.java
@@ -26,6 +26,8 @@ import org.telegram.telegrambots.meta.api.objects.User;
 @AllArgsConstructor
 @Builder
 public class ChatMemberBanned implements ChatMember {
+    public static final String STATUS = "kicked";
+
     private static final String STATUS_FIELD = "status";
     private static final String USER_FIELD = "user";
     private static final String UNTILDATE_FIELD = "until_date";
@@ -34,7 +36,7 @@ public class ChatMemberBanned implements ChatMember {
      * The member's status in the chat, always “kicked”
      */
     @JsonProperty(STATUS_FIELD)
-    private final String status = "kicked";
+    private final String status = STATUS;
     /**
      * Information about the user
      */

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberLeft.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberLeft.java
@@ -26,6 +26,8 @@ import org.telegram.telegrambots.meta.api.objects.User;
 @AllArgsConstructor
 @Builder
 public class ChatMemberLeft implements ChatMember {
+    public static final String STATUS = "left";
+
     private static final String STATUS_FIELD = "status";
     private static final String USER_FIELD = "user";
 
@@ -33,7 +35,7 @@ public class ChatMemberLeft implements ChatMember {
      * The member's status in the chat, always “left”
      */
     @JsonProperty(STATUS_FIELD)
-    private final String status = "left";
+    private final String status = STATUS;
     /**
      * Information about the user
      */

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberMember.java
@@ -26,6 +26,8 @@ import org.telegram.telegrambots.meta.api.objects.User;
 @AllArgsConstructor
 @Builder
 public class ChatMemberMember implements ChatMember {
+    public static final String STATUS = "member";
+
     private static final String STATUS_FIELD = "status";
     private static final String USER_FIELD = "user";
 
@@ -33,7 +35,7 @@ public class ChatMemberMember implements ChatMember {
      * The member's status in the chat, always “member”
      */
     @JsonProperty(STATUS_FIELD)
-    private final String status = "member";
+    private final String status = STATUS;
     /**
      * Information about the user
      */

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberOwner.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberOwner.java
@@ -26,6 +26,8 @@ import org.telegram.telegrambots.meta.api.objects.User;
 @AllArgsConstructor
 @Builder
 public class ChatMemberOwner implements ChatMember {
+    public static final String STATUS = "creator";
+
     private static final String STATUS_FIELD = "status";
     private static final String USER_FIELD = "user";
     private static final String CUSTOMTITLE_FIELD = "custom_title";
@@ -35,7 +37,7 @@ public class ChatMemberOwner implements ChatMember {
      * The member's status in the chat, always “creator”
      */
     @JsonProperty(STATUS_FIELD)
-    private final String status = "creator";
+    private final String status = STATUS;
     /**
      * Information about the user
      */

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberRestricted.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberRestricted.java
@@ -26,6 +26,8 @@ import org.telegram.telegrambots.meta.api.objects.User;
 @AllArgsConstructor
 @Builder
 public class ChatMemberRestricted implements ChatMember {
+    public static final String STATUS = "restricted";
+
     private static final String STATUS_FIELD = "status";
     private static final String USER_FIELD = "user";
     private static final String ISMEMBER_FIELD = "is_member";
@@ -43,7 +45,7 @@ public class ChatMemberRestricted implements ChatMember {
      * The member's status in the chat, always “restricted”
      */
     @JsonProperty(STATUS_FIELD)
-    private final String status = "restricted";
+    private final String status = STATUS;
     /**
      * Information about the user
      */


### PR DESCRIPTION
All `ChatMember` implementations have `user` field, so we don't need to cast to particular class in most cases