### PR TITLE
Fixed Warning with RestAPI registration to ResourceConfig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <json.version>20180813</json.version>
         <slf4j.version>1.7.30</slf4j.version>
         <jakarta.annotation.version>1.3.5</jakarta.annotation.version>
-        <lombok.version>1.18.16</lombok.version>
+        <lombok.version>1.18.20</lombok.version>
         <guava.version>30.0-jre</guava.version>
     </properties>
 

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/CallbacksProxy.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/CallbacksProxy.java
@@ -1,0 +1,25 @@
+package org.telegram.telegrambots.updatesreceivers;
+
+import org.telegram.telegrambots.meta.generics.WebhookBot;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CallbacksProxy {
+
+    private final ConcurrentHashMap<String, WebhookBot> callbacks = new ConcurrentHashMap<>();
+
+    public boolean containsBotPath(String botPath) {
+        return callbacks.containsKey(botPath);
+    }
+
+    public WebhookBot getWebhookBot(String botPath) {
+        return callbacks.get(botPath);
+    }
+
+    public void registerCallback(WebhookBot callback) {
+        if (!callbacks.containsKey(callback.getBotPath())) {
+            callbacks.put(callback.getBotPath(), callback);
+        }
+    }
+
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/RestApi.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/RestApi.java
@@ -5,8 +5,8 @@ import org.telegram.telegrambots.Constants;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-import org.telegram.telegrambots.meta.generics.WebhookBot;
 
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -15,7 +15,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Ruben Bermudez
@@ -25,25 +24,18 @@ import java.util.concurrent.ConcurrentHashMap;
 @Path(Constants.WEBHOOK_URL_PATH)
 @Slf4j
 public class RestApi {
-    private final ConcurrentHashMap<String, WebhookBot> callbacks = new ConcurrentHashMap<>();
 
-    public RestApi() {
-    }
-
-    public void registerCallback(WebhookBot callback) {
-        if (!callbacks.containsKey(callback.getBotPath())) {
-            callbacks.put(callback.getBotPath(), callback);
-        }
-    }
+    @Inject
+    CallbacksProxy callbacksProxy;
 
     @POST
     @Path("/{botPath}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateReceived(@PathParam("botPath") String botPath, Update update) {
-        if (callbacks.containsKey(botPath)) {
+        if (callbacksProxy.containsBotPath(botPath)) {
             try {
-                BotApiMethod<?> response = callbacks.get(botPath).onWebhookUpdateReceived(update);
+                BotApiMethod<?> response = callbacksProxy.getWebhookBot(botPath).onWebhookUpdateReceived(update);
                 if (response != null) {
                     response.validate();
                 }
@@ -61,7 +53,7 @@ public class RestApi {
     @Path("/{botPath}")
     @Produces(MediaType.APPLICATION_JSON)
     public String testReceived(@PathParam("botPath") String botPath) {
-        if (callbacks.containsKey(botPath)) {
+        if (callbacksProxy.containsBotPath(botPath)) {
             return "Hi there " + botPath + "!";
         } else {
             return "Callback not found for " + botPath;


### PR DESCRIPTION
The current strategy for creating a DefaultWebhook consisted of registering a Resource to ResourceConfig after its instantiation; this caused this warning message by Jersey:
````
WARNING: A provider org.telegram.telegrambots.updatesreceivers.RestApi registered in SERVER runtime does not implement any provider interfaces applicable in the SERVER runtime. Due to constraint configuration problems the provider org.telegram.telegrambots.updatesreceivers.RestApi will be ignored. 
````
I propose registering RestApi without instancing it and introducing a CallbacksProxy to store callbacks; in RestApi this object is Injected by H2K; for this purpose, I registered a Binder to ResourceConfig with the singleton instance of CallbacksProxy.