### PR TITLE
Rename entities in class InputMedia

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/media/InputMedia.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/media/InputMedia.java
@@ -43,7 +43,7 @@ public abstract class InputMedia implements Validable, BotApiObject {
     public static final String MEDIA_FIELD = "media";
     public static final String CAPTION_FIELD = "caption";
     public static final String PARSEMODE_FIELD = "parse_mode";
-    public static final String ENTITIES_FIELD = "entities";
+    public static final String ENTITIES_FIELD = "caption_entities";
 
     /**
      * File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended),


### PR DESCRIPTION
According to [official documentation](https://core.telegram.org/bots/api#sendphoto), field `entities` should be named as `caption_entities`.