### PR TITLE
Add Webhook implementation for CommandBot

### DIFF
--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/CommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/CommandBot.java
@@ -1,0 +1,43 @@
+package org.telegram.telegrambots.extensions.bots.commandbot;
+
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * This interface represents common functions for command bots
+ *
+ * @author Andrey Korsakov (loolzaaa)
+ */
+public interface CommandBot {
+    /**
+     * Process all updates, that are not commands.
+     *
+     * @param update the update
+     * @warning Commands that have valid syntax but are not registered on this bot,
+     * won't be forwarded to this method <b>if a default action is present</b>.
+     */
+    void processNonCommandUpdate(Update update);
+
+    /**
+     * This method is called when user sends a not registered command. By default it will just call processNonCommandUpdate(),
+     * override it in your implementation if you want your bot to do other things, such as sending an error message
+     *
+     * @param update Received update from Telegram
+     */
+    void processInvalidCommandUpdate(Update update);
+
+    /**
+     * Override this function in your bot implementation to filter messages with commands
+     * <p>
+     * For example, if you want to prevent commands execution incoming from group chat:
+     * #
+     * # return !message.getChat().isGroupChat();
+     * #
+     *
+     * @param message Received message
+     * @return true if the message must be ignored by the command bot and treated as a non command message,
+     * false otherwise
+     * @note Default implementation doesn't filter anything
+     */
+    boolean filter(Message message);
+}

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/CommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/CommandBot.java
@@ -24,7 +24,9 @@ public interface CommandBot {
      *
      * @param update Received update from Telegram
      */
-    void processInvalidCommandUpdate(Update update);
+    default void processInvalidCommandUpdate(Update update) {
+        processNonCommandUpdate(update);
+    }
 
     /**
      * Override this function in your bot implementation to filter messages with commands
@@ -39,5 +41,7 @@ public interface CommandBot {
      * false otherwise
      * @note Default implementation doesn't filter anything
      */
-    boolean filter(Message message);
+    default boolean filter(Message message) {
+        return false;
+    }
 }

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramLongPollingCommandBot.java
@@ -71,16 +71,6 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
     }
 
     @Override
-    public void processInvalidCommandUpdate(Update update) {
-        processNonCommandUpdate(update);
-    }
-
-    @Override
-    public boolean filter(Message message) {
-        return false;
-    }
-
-    @Override
     public final boolean register(IBotCommand botCommand) {
         return commandRegistry.register(botCommand);
     }

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramWebhookCommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramWebhookCommandBot.java
@@ -1,62 +1,63 @@
 package org.telegram.telegrambots.extensions.bots.commandbot;
 
 
-import org.telegram.telegrambots.meta.api.objects.Message;
-import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.meta.bots.AbsSender;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
-import org.telegram.telegrambots.bots.TelegramLongPollingBot;
+import org.telegram.telegrambots.bots.TelegramWebhookBot;
 import org.telegram.telegrambots.extensions.bots.commandbot.commands.CommandRegistry;
 import org.telegram.telegrambots.extensions.bots.commandbot.commands.IBotCommand;
 import org.telegram.telegrambots.extensions.bots.commandbot.commands.ICommandRegistry;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.bots.AbsSender;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
 /**
- * This class adds command functionality to the TelegramLongPollingBot
+ * This class adds command functionality to the TelegramWebhookBot
  *
- * @author Timo Schulz (Mit0x2)
+ * @author Andrey Korsakov (loolzaaa)
  */
-public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingBot implements CommandBot, ICommandRegistry {
+public abstract class TelegramWebhookCommandBot extends TelegramWebhookBot implements CommandBot, ICommandRegistry {
     private final CommandRegistry commandRegistry;
 
     /**
-     * Creates a TelegramLongPollingCommandBot using default options
+     * Creates a TelegramWebhookCommandBot using default options
      * Use ICommandRegistry's methods on this bot to register commands
      *
      */
-    public TelegramLongPollingCommandBot() {
+    public TelegramWebhookCommandBot() {
         this(new DefaultBotOptions());
     }
 
     /**
-     * Creates a TelegramLongPollingCommandBot with custom options and allowing commands with
+     * Creates a TelegramWebhookCommandBot with custom options and allowing commands with
      * usernames
      * Use ICommandRegistry's methods on this bot to register commands
      *
      * @param options     Bot options
      */
-    public TelegramLongPollingCommandBot(DefaultBotOptions options) {
+    public TelegramWebhookCommandBot(DefaultBotOptions options) {
         this(options, true);
     }
 
     /**
-     * Creates a TelegramLongPollingCommandBot
+     * Creates a TelegramWebhookCommandBot
      * Use ICommandRegistry's methods on this bot to register commands
      *
      * @param options                   Bot options
      * @param allowCommandsWithUsername true to allow commands with parameters (default),
      *                                  false otherwise
      */
-    public TelegramLongPollingCommandBot(DefaultBotOptions options, boolean allowCommandsWithUsername) {
+    public TelegramWebhookCommandBot(DefaultBotOptions options, boolean allowCommandsWithUsername) {
         super(options);
         this.commandRegistry = new CommandRegistry(allowCommandsWithUsername, this::getBotUsername);
     }
 
     @Override
-    public final void onUpdateReceived(Update update) {
+    public BotApiMethod<?> onWebhookUpdateReceived(Update update) {
         if (update.hasMessage()) {
             Message message = update.getMessage();
             if (message.isCommand() && !filter(message)) {
@@ -64,10 +65,11 @@ public abstract class TelegramLongPollingCommandBot extends TelegramLongPollingB
                     //we have received a not registered command, handle it as invalid
                     processInvalidCommandUpdate(update);
                 }
-                return;
+                return null;
             }
         }
         processNonCommandUpdate(update);
+        return null;
     }
 
     @Override

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramWebhookCommandBot.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/TelegramWebhookCommandBot.java
@@ -73,16 +73,6 @@ public abstract class TelegramWebhookCommandBot extends TelegramWebhookBot imple
     }
 
     @Override
-    public void processInvalidCommandUpdate(Update update) {
-        processNonCommandUpdate(update);
-    }
-
-    @Override
-    public boolean filter(Message message) {
-        return false;
-    }
-
-    @Override
     public final boolean register(IBotCommand botCommand) {
         return commandRegistry.register(botCommand);
     }
@@ -116,10 +106,4 @@ public abstract class TelegramWebhookCommandBot extends TelegramWebhookBot imple
     public final IBotCommand getRegisteredCommand(String commandIdentifier) {
         return commandRegistry.getRegisteredCommand(commandIdentifier);
     }
-
-    /**
-     * @return Bot username
-     */
-    @Override
-    public abstract String getBotUsername();
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/ServerlessWebhook.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/ServerlessWebhook.java
@@ -1,0 +1,55 @@
+package org.telegram.telegrambots.updatesreceivers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
+import org.telegram.telegrambots.meta.generics.Webhook;
+import org.telegram.telegrambots.meta.generics.WebhookBot;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class ServerlessWebhook implements Webhook {
+
+    private final ConcurrentHashMap<String, WebhookBot> callbacks = new ConcurrentHashMap<>();
+
+    public BotApiMethod<?> updateReceived(String botPath, Update update) throws TelegramApiValidationException {
+        if (callbacks.containsKey(botPath)) {
+            try {
+                BotApiMethod<?> response = callbacks.get(botPath).onWebhookUpdateReceived(update);
+                if (response != null) {
+                    response.validate();
+                }
+                return response;
+            } catch (TelegramApiValidationException e) {
+                log.error(e.getLocalizedMessage(), e);
+                throw e;
+            }
+        } else {
+            throw new NoSuchElementException(String.format("Callback '%s' not exist", botPath));
+        }
+    }
+
+    @Override
+    public void startServer() throws TelegramApiException {
+        // Do nothing, because there is no abstraction for webhook without server
+    }
+
+    @Override
+    public void registerWebhook(WebhookBot callback) {
+        callbacks.putIfAbsent(callback.getBotPath(), callback);
+    }
+
+    @Override
+    public void setInternalUrl(String internalUrl) {
+        throw new UnsupportedOperationException("Not implemented for Serverless Webhook");
+    }
+
+    @Override
+    public void setKeyStore(String keyStore, String keyStorePassword) throws TelegramApiException {
+        throw new UnsupportedOperationException("Not implemented for Serverless Webhook");
+    }
+}

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/ServerlessWebhookTest.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/ServerlessWebhookTest.java
@@ -1,0 +1,298 @@
+package org.telegram.telegrambots.test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.test.Fakes.FakeWebhook;
+import org.telegram.telegrambots.updatesreceivers.ServerlessWebhook;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author Andrey Korsakov
+ * @version 1.0
+ */
+public class ServerlessWebhookTest {
+
+    final FakeWebhook webhookBot = new FakeWebhook();
+    ServerlessWebhook serverlessWebhook;
+
+    @BeforeEach
+    void setUp() {
+        serverlessWebhook = new ServerlessWebhook();
+        serverlessWebhook.registerWebhook(webhookBot);
+    }
+
+    @Test
+    public void TestSendMessage() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getSendMessage());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"@test\",\"text\":\"Hithere\",\"parse_mode\":\"html\",\"reply_to_message_id\":12,\"reply_markup\":{\"force_reply\":true},\"method\":\"sendmessage\"}", map(result));
+    }
+
+    @Test
+    public void TestAnswerCallbackQuery() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getAnswerCallbackQuery());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"callback_query_id\":\"id\",\"text\":\"text\",\"show_alert\":true,\"method\":\"answercallbackquery\"}", map(result));
+    }
+
+    @Test
+    public void TestAnswerInlineQuery() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getAnswerInlineQuery());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"inline_query_id\":\"id\",\"results\":[{\"type\":\"article\",\"id\":\"0\",\"title\":\"Title\",\"input_message_content\":{\"message_text\":\"Text\",\"parse_mode\":\"Markdown\"},\"reply_markup\":{\"inline_keyboard\":[[{\"text\":\"Button1\",\"callback_data\":\"Callback\"}]]},\"url\":\"Url\",\"hide_url\":false,\"description\":\"Description\",\"thumb_url\":\"ThumbUrl\",\"thumb_width\":10,\"thumb_height\":20},{\"type\":\"photo\",\"id\":\"1\",\"photo_url\":\"PhotoUrl\",\"mime_type\":\"image/jpg\",\"photo_width\":10,\"photo_height\":20,\"thumb_url\":\"ThumbUrl\",\"title\":\"Title\",\"description\":\"Description\",\"caption\":\"Caption\",\"input_message_content\":{\"message_text\":\"Text\",\"parse_mode\":\"Markdown\"},\"reply_markup\":{\"inline_keyboard\":[[{\"text\":\"Button1\",\"callback_data\":\"Callback\"}]]},\"caption_entities\":[]}],\"cache_time\":100,\"is_personal\":true,\"next_offset\":\"3\",\"switch_pm_text\":\"pmText\",\"switch_pm_parameter\":\"PmParameter\",\"method\":\"answerInlineQuery\"}",
+                map(result));
+    }
+
+    @Test
+    public void TestEditMessageCaption() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getEditMessageCaption());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"ChatId\",\"message_id\":1,\"caption\":\"Caption\"," +
+                "\"reply_markup\":{\"inline_keyboard\":[[{\"text\":\"Button1\",\"callback_data\":\"Callback\"}]]}," +
+                "\"caption_entities\":[],\"method\":\"editmessagecaption\"}", map(result));
+    }
+
+    @Test
+    public void TestEditMessageReplyMarkup() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getEditMessageReplyMarkup());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"inline_message_id\":\"12345\",\"reply_markup\":{" +
+                "\"inline_keyboard\":[[{\"text\":\"Button1\"," +
+                "\"callback_data\":\"Callback\"}]]},\"method\":\"editmessagereplymarkup\"}",
+                map(result));
+    }
+
+    @Test
+    public void TestEditMessageText() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getEditMessageText());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"ChatId\",\"message_id\":1,\"text\":\"Text\"," +
+                "\"parse_mode\":\"Markdown\",\"reply_markup\":{\"" +
+                "inline_keyboard\":[[{\"text\":\"Button1\",\"callback_data\"" +
+                ":\"Callback\"}]]},\"method\":\"editmessagetext\"}", map(result));
+    }
+
+    @Test
+    public void TestForwardMessage() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getForwardMessage());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"To\",\"from_chat_id\":\"From\",\"message_id\":15," +
+                "\"disable_notification\":true,\"method\":\"forwardmessage\"}", map(result));
+    }
+
+    @Test
+    public void TestGetChat() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getGetChat());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"method\":\"getChat\"}", map(result));
+    }
+
+    @Test
+    public void TestGetChatAdministrators() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getChatAdministrators());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"method\":\"getChatAdministrators\"}", map(result));
+    }
+
+    @Test
+    public void TestGetChatMember() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getChatMember());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"user_id\":98765,\"method\":\"getChatMember\"}", map(result));
+    }
+
+    @Test
+    public void TestGetChatMembersCount() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getChatMemberCount());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"method\":\"getChatMemberCount\"}", map(result));
+    }
+
+    @Test
+    public void TestGetFile() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getGetFile());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"file_id\":\"FileId\",\"method\":\"getFile\"}", map(result));
+    }
+
+    @Test
+    public void TestGetGameHighScores() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getGetGameHighScores());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"message_id\":67890,\"user_id\":98765,\"method\":\"getGameHighScores\"}", map(result));
+    }
+
+    @Test
+    public void TestGetMe() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getGetMe());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"method\":\"getme\"}", map(result));
+    }
+
+    @Test
+    public void TestGetUserProfilePhotos() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getGetUserProfilePhotos());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"user_id\":98765,\"offset\":3,\"limit\":10,\"method\":\"getuserprofilephotos\"}", map(result));
+    }
+
+    @Test
+    public void TestGetWebhookInfo() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getGetWebhookInfo());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"method\":\"getwebhookinfo\"}", map(result));
+    }
+
+    @Test
+    public void TestKickChatMember() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getBanChatMember());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"user_id\":98765,\"method\":\"banChatMember\"}", map(result));
+    }
+
+    @Test
+    public void TestLeaveChat() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getLeaveChat());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"method\":\"leaveChat\"}", map(result));
+    }
+
+    @Test
+    public void TestSendChatAction() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getSendChatAction());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"action\":\"record_video\",\"method\":\"sendChatAction\"}", map(result));
+    }
+
+    @Test
+    public void TestSendContact() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getSendContact());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"phone_number\":\"123456789\",\"first_name\":\"First Name\",\"last_name\":\"Last Name\",\"reply_to_message_id\":54,\"reply_markup\":{\"keyboard\":[[{\"text\":\"Button1\",\"request_contact\":true}]],\"resize_keyboard\":true,\"one_time_keyboard\":true,\"selective\":true},\"method\":\"sendContact\"}", map(result));
+    }
+
+    @Test
+    public void TestSendGame() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getSendGame());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"game_short_name\":\"MyGame\",\"method\":\"sendGame\"}", map(result));
+    }
+
+    @Test
+    public void TestSendLocation() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getSendLocation());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"latitude\":12.5,\"longitude\":21.5,\"reply_to_message_id\":53,\"method\":\"sendlocation\"}", map(result));
+    }
+
+    @Test
+    public void TestSendVenue() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getSendVenue());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"latitude\":12.5,\"longitude\":21.5,\"title\":\"Venue Title\",\"address\":\"Address\",\"foursquare_id\":\"FourId\",\"reply_to_message_id\":53,\"method\":\"sendVenue\"}", map(result));
+    }
+
+    @Test
+    public void TestSetGameScore() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getSetGameScore());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"inline_message_id\":\"12345\",\"disable_edit_message\":true,\"user_id\":98765,\"score\":12,\"method\":\"setGameScore\"}", map(result));
+    }
+
+    @Test
+    public void TestUnbanChatMember() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getUnbanChatMember());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"user_id\":98765,\"method\":\"unbanchatmember\"}", map(result));
+    }
+
+    @Test
+    public void TestSendInvoice() throws Exception {
+        webhookBot.setReturnValue(BotApiMethodHelperFactory.getSendInvoice());
+
+        BotApiMethod<?> result = serverlessWebhook.updateReceived(webhookBot.getBotPath(), getUpdate());
+
+        assertEquals("{\"chat_id\":\"12345\",\"title\":\"Random title\",\"description\":\"Random description\"," +
+                "\"payload\":\"Random Payload\",\"provider_token\":\"Random provider token\",\"start_parameter\":\"STARTPARAM\"," +
+                "\"currency\":\"EUR\",\"prices\":[{\"label\":\"LABEL\",\"amount\":1000}],\"max_tip_amount\":100," +
+                "\"suggested_tip_amounts\":[10,50,75],\"method\":\"sendinvoice\"}", map(result));
+    }
+
+    private Update getUpdate() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.readValue("{\"update_id\": 10}", Update.class);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private <T extends Serializable> String map(BotApiMethod<T> method) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(method);
+        } catch (JsonProcessingException e) {
+            fail("Failed to serialize");
+            return null;
+        }
+    }
+}

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/TestRestApi.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/TestRestApi.java
@@ -227,7 +227,7 @@ public class TestRestApi extends JerseyTest {
                         .request(MediaType.APPLICATION_JSON)
                         .post(entity, GetChatMemberCount.class);
 
-        assertEquals("{\"chat_id\":\"12345\",\"method\":\"getChatMembersCount\"}", map(result));
+        assertEquals("{\"chat_id\":\"12345\",\"method\":\"getChatMemberCount\"}", map(result));
     }
 
     @Test
@@ -305,7 +305,7 @@ public class TestRestApi extends JerseyTest {
                         .request(MediaType.APPLICATION_JSON)
                         .post(entity, BanChatMember.class);
 
-        assertEquals("{\"chat_id\":\"12345\",\"user_id\":98765,\"method\":\"kickchatmember\"}", map(result));
+        assertEquals("{\"chat_id\":\"12345\",\"user_id\":98765,\"method\":\"banChatMember\"}", map(result));
     }
 
     @Test


### PR DESCRIPTION
List of changes:

- Extract command behaviour to separate interface with defaults
- Remove methods from CommandBot implementation because of default behaviour
- Add TelegramWebhookCommandBot implemetation
- Add ServerlessWebhook implementation (resolve #478)

Example of implementation [here](https://github.com/loolzaaa/telegram-service-bot) -> service-bot-spring