### PR TITLE
Move configureHttpContext from DefaultAbsSender

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -48,7 +48,6 @@ import org.telegram.telegrambots.meta.updateshandlers.SentCallback;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -82,7 +81,7 @@ public abstract class DefaultAbsSender extends AbsSender {
 
         httpClient = TelegramHttpClientBuilder.build(options);
         this.telegramFileDownloader = new TelegramFileDownloader(httpClient, this::getBotToken);
-        configureHttpContext();
+        options.configureHttpContext();
 
         final RequestConfig configFromOptions = options.getRequestConfig();
         if (configFromOptions != null) {
@@ -1049,22 +1048,6 @@ public abstract class DefaultAbsSender extends AbsSender {
     }
 
     // Private methods
-
-    private void configureHttpContext() {
-
-        if (options.getProxyType() != DefaultBotOptions.ProxyType.NO_PROXY) {
-            InetSocketAddress socksaddr = new InetSocketAddress(options.getProxyHost(), options.getProxyPort());
-            options.getHttpContext().setAttribute("socketAddress", socksaddr);
-        }
-
-        if (options.getProxyType() == DefaultBotOptions.ProxyType.SOCKS4) {
-            options.getHttpContext().setAttribute("socksVersion", 4);
-        }
-        if (options.getProxyType() == DefaultBotOptions.ProxyType.SOCKS5) {
-            options.getHttpContext().setAttribute("socksVersion", 5);
-        }
-
-    }
 
     private <T extends Serializable, Method extends BotApiMethod<T>> String sendMethodRequest(Method method) throws TelegramApiValidationException, IOException {
         method.validate();

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
@@ -7,6 +7,7 @@ import org.telegram.telegrambots.meta.ApiConstants;
 import org.telegram.telegrambots.meta.generics.BotOptions;
 import org.telegram.telegrambots.meta.generics.BackOff;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 
 /**
@@ -28,6 +29,22 @@ public class DefaultBotOptions implements BotOptions {
     private int proxyPort;
     private int getUpdatesTimeout;
     private int getUpdatesLimit;
+
+    void configureHttpContext() {
+
+        if (getProxyType() != ProxyType.NO_PROXY) {
+            InetSocketAddress socksaddr = new InetSocketAddress(getProxyHost(), getProxyPort());
+            getHttpContext().setAttribute("socketAddress", socksaddr);
+        }
+
+        if (getProxyType() == ProxyType.SOCKS4) {
+            getHttpContext().setAttribute("socksVersion", 4);
+        }
+        if (getProxyType() == ProxyType.SOCKS5) {
+            getHttpContext().setAttribute("socksVersion", 5);
+        }
+
+    }
 
     public enum ProxyType {
         NO_PROXY,


### PR DESCRIPTION
The selected method reduced cohesion inside the DefaultAbsSender as the configureHttpContext method used properties of the DefaultBotOptions class. Hence it was moved to the DefaultBotOptions