### PR TITLE
Pull up method to reduce duplication

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/BooleanBotApiMethod.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/BooleanBotApiMethod.java
@@ -1,0 +1,45 @@
+package org.telegram.telegrambots.meta.api.methods;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * @author Ruben Bermudez
+ * @version 1.0
+ *
+ * A method of Telegram Bots Api that is fully supported in json format
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class BooleanBotApiMethod<T extends Serializable> extends PartialBotApiMethod<T> {
+    protected static final String METHOD_FIELD = "method";
+
+    /**
+     * Getter for method path (that is the same as method name)
+     * @return Method path
+     */
+    @JsonProperty(METHOD_FIELD)
+    public abstract String getMethod();
+
+    @Override
+    public T deserializeResponse(String answer) throws TelegramApiRequestException {
+        try {
+            ApiResponse<T> result = OBJECT_MAPPER.readValue(answer,
+                    new TypeReference<ApiResponse<T>>(){});
+            if (result.getOk()) {
+                return result.getResult();
+            } else {
+                throw new TelegramApiRequestException("Error sending commands", result);
+            }
+        } catch (IOException e) {
+            throw new TelegramApiRequestException("Unable to deserialize response", e);
+        }
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/DeleteMyCommands.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/DeleteMyCommands.java
@@ -9,13 +9,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.BooleanBotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.commands.scope.BotCommandScope;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 /**
  * @author Ruben Bermudez
@@ -32,7 +33,7 @@ import java.io.IOException;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class DeleteMyCommands extends BotApiMethod<Boolean> {
+public class DeleteMyCommands extends BooleanBotApiMethod {
     public static final String PATH = "deleteMyCommands";
 
     private static final String SCOPE_FIELD = "scope";
@@ -56,21 +57,6 @@ public class DeleteMyCommands extends BotApiMethod<Boolean> {
     @Override
     public String getMethod() {
         return PATH;
-    }
-
-    @Override
-    public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending commands", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/SetMyCommands.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/SetMyCommands.java
@@ -11,6 +11,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.Singular;
 import lombok.ToString;
+import org.telegram.telegrambots.meta.api.methods.BooleanBotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.commands.BotCommand;
@@ -35,7 +36,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class SetMyCommands extends BotApiMethod<Boolean> {
+public class SetMyCommands extends BooleanBotApiMethod {
     public static final String PATH = "setMyCommands";
 
     private static final String COMMANDS_FIELD = "commands";
@@ -68,21 +69,6 @@ public class SetMyCommands extends BotApiMethod<Boolean> {
     @Override
     public String getMethod() {
         return PATH;
-    }
-
-    @Override
-    public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending commands", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
     }
 
     @Override


### PR DESCRIPTION
DeserializeResponse method was duplicated twice in Delete and Set, so was pulled upto an intermediate class BooleanBotApiMethod as there was a third class using deserializeResponse which had a different signature, hence the intermediate class.