### PR TITLE
Use correct code example for AbilityExtensions

### DIFF
--- a/TelegramBots.wiki/abilities/Ability-Extensions.md
+++ b/TelegramBots.wiki/abilities/Ability-Extensions.md
@@ -7,7 +7,7 @@ public class MrGoodGuy implements AbilityExtension {
            .name("nice")
            .privacy(PUBLIC)
            .locality(ALL)
-           .action(ctx -> silent.send("You're awesome!", ctx.chatId())
+           .action(ctx -> ctx.bot().silent().send("You're awesome!", ctx.chatId())
           );
   }
 }
@@ -18,7 +18,7 @@ public class MrBadGuy implements AbilityExtension {
            .name("notnice")
            .privacy(PUBLIC)
            .locality(ALL)
-           .action(ctx -> silent.send("You're horrible!", ctx.chatId())
+           .action(ctx -> ctx.bot().silent().send("You're horrible!", ctx.chatId())
           );
   }
  }


### PR DESCRIPTION
Using just `silent` will cause a compilation error