### PR TITLE
Change the format of reply exception log.

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -673,8 +673,13 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
         try {
             return callable.call();
         } catch(Exception ex) {
-            log.error(format("Reply [%s] failed to check for conditions. " +
-                "Make sure you're safeguarding against all possible updates.", name));
+            String msg = format("Reply [%s] failed to check for conditions. " +
+                    "Make sure you're safeguarding against all possible updates.", name);
+            if (log.isDebugEnabled()) {
+                log.error(msg, ex);
+            } else {
+                log.error(msg);
+            }
         }
         return false;
     }


### PR DESCRIPTION
Output exception details in exception handling to help developers troubleshoot problems. At the same time, by checking whether the debug level is enabled, too many output logs in the production environment can be avoided. (I guess the original design was for this reason)

After the change, when the debug level is not enabled, the log format is no different from that before. When the debug level is enabled, exception stack information is output to help developers check for problems.

### Example

#### Previous format / Debug level not enabled
```
[12:10:56.253 ERROR][o.t.a.api.bot.BaseAbilityBot][Bot Telegram Executor]: Reply [null] failed to check for conditions. Make sure you're safeguarding against all possible updates.
```
#### Debug level enabled
```
15:08:47.369 [main] ERROR org.telegram.abilitybots.api.bot.BaseAbilityBot - Reply [null] failed to check for conditions. Make sure you're safeguarding against all possible updates.
java.lang.RuntimeException: Throwing an exception inside the reply conditions (flags)
	at ......
```

