### PR TITLE
Wrong assertion always true(compares same object)

### DIFF
--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/AbilityBotTest.java
@@ -383,7 +383,7 @@ public class AbilityBotTest {
     Map<String, Long> expectedUserIds = ImmutableMap.of(changedUser.getUserName(), changedUser.getId());
     Map<Long, User> expectedUsers = ImmutableMap.of(changedUser.getId(), changedUser);
     assertEquals(bot.userIds(), expectedUserIds, "User was not properly edited");
-    assertEquals(expectedUsers, expectedUsers, "User was not properly edited");
+    assertEquals(bot.users(), expectedUsers, "User was not properly edited");
   }
 
   @Test


### PR DESCRIPTION
Probably due to carelessness the same object is compared and the assertion is always true. Sonarlint raised this issue.