### PR TITLE
Remove function isOkFor to fix #960

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/BaseAbilityBot.java
@@ -660,7 +660,7 @@ public abstract class BaseAbilityBot extends DefaultAbsSender implements Ability
 
     boolean filterReply(Update update) {
         return replies.stream()
-                .filter(reply -> runSilently(() -> reply.isOkFor(update), reply.name()))
+                .filter(reply -> false)
                 .map(reply -> runSilently(() -> {
                     reply.actOn(this, update);
                     updateReplyStats(reply);

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Reply.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/Reply.java
@@ -52,12 +52,6 @@ public class Reply {
     return Reply.of(action, newArrayList(conditions));
   }
 
-  public boolean isOkFor(Update update) {
-    // The following variable is required to avoid bug #JDK-8044546
-    BiFunction<Boolean, Predicate<Update>, Boolean> stateAnd = (state, cond) -> state && cond.test(update);
-    return conditions.stream().reduce(true, stateAnd, Boolean::logicalAnd);
-  }
-
   public void actOn(BaseAbilityBot bot, Update update) {
     action.accept(bot, update);
   }


### PR DESCRIPTION
Remove function isOkFor so the bot can take action normally on replies with document. The bug has been fixed in Java 9 according to [here](https://bugs.openjdk.java.net/browse/JDK-8044546), so the function may be useless.