### PR TITLE
Add a validator for markdown message

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/sender/SilentSender.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/sender/SilentSender.java
@@ -62,12 +62,12 @@ public class SilentSender {
         italic = false;
       if (valid && message.charAt(i) == '[' )
         inline_URL = false;
-      if (valid && (i < message.length() - 1 && message.charAt(i) == '`' && message.charAt(i+1) != '`'))
-        inline = false;
-      if (valid && (i < message.length() - 5 && message.charAt(i) == '`' && message.charAt(i+1) == '`' && message.charAt(i+2) == '`')) {
+      if (valid && (i < message.length() - 2 && message.charAt(i) == '`' && message.charAt(i+1) == '`' && message.charAt(i+2) == '`')) {
         language = false;
         i +=2;
       }
+      if (valid && message.charAt(i) == '`' && language))
+        inline = false;
       //skips the escape character
       if (valid & message.charAt(i) == '\\')
         i++;

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/sender/SilentSender.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/sender/SilentSender.java
@@ -27,6 +27,58 @@ public class SilentSender {
     this.sender = sender;
   }
 
+  /**
+   * A validator for markdown style message to avoid exception from Telegram API.
+   * @author SUSTechDXiang
+   * @version 1.0
+   * @return
+   */
+  public Optional<Message> sendMdValidator(String message, long id) {
+
+    boolean bold = true;
+    boolean italic = true;
+    boolean inline = true;
+    boolean inline_URL = true;
+    boolean language = true;
+    boolean valid = true;
+    for (int i = 0; i < message.length(); i++){
+      //judges if it is end of an entity
+      if (!bold && message.charAt(i) == '*' )
+        bold = true;
+      if (!italic && message.charAt(i) == '_' )
+        italic = true;
+      if (!inline && message.charAt(i) == '`')
+        inline = true;
+      if (!inline_URL && message.charAt(i) == ']')
+        inline_URL = true;
+      if (!language && (i < message.length() - 2 && message.charAt(i) == '`' && message.charAt(i+1) == '`' && message.charAt(i+2) == '`')) {
+        language = true;
+        i +=2;
+      }
+      //judges if it is start of an entity
+      if (valid && message.charAt(i) == '*' )
+        bold = false;
+      if (valid && message.charAt(i) == '_' )
+        italic = false;
+      if (valid && message.charAt(i) == '[' )
+        inline_URL = false;
+      if (valid && (i < message.length() - 1 && message.charAt(i) == '`' && message.charAt(i+1) != '`'))
+        inline = false;
+      if (valid && (i < message.length() - 5 && message.charAt(i) == '`' && message.charAt(i+1) == '`' && message.charAt(i+2) == '`')) {
+        language = false;
+        i +=2;
+      }
+      //skips the escape character
+      if (valid & message.charAt(i) == '\\')
+        i++;
+
+      //if an entity does not end, it is not a valid markdown
+      valid = bold && italic && inline && inline_URL && language ;
+    }
+
+    return doSendMessage(message, id, valid);
+  }
+
   public Optional<Message> send(String message, long id) {
     return doSendMessage(message, id, false);
   }


### PR DESCRIPTION
fix #705
I write a validator for markdown style message. It will filter out invalid markdown style messages and send normal messages instead. So that it will not receive an exception.