### PR TITLE
Refactoring method implementation public abstract T deserializeRespon…

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerCallbackQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerCallbackQuery.java
@@ -1,21 +1,9 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerCallbackQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerCallbackQuery.java
@@ -76,17 +76,7 @@ public class AnswerCallbackQuery extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error answering callback query", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error answering callback query");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerInlineQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerInlineQuery.java
@@ -1,23 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResult;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerInlineQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerInlineQuery.java
@@ -97,16 +97,6 @@ public class AnswerInlineQuery extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error answering inline query", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error answering inline query");
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerPreCheckoutQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerPreCheckoutQuery.java
@@ -1,21 +1,9 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerPreCheckoutQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerPreCheckoutQuery.java
@@ -74,16 +74,6 @@ public class AnswerPreCheckoutQuery extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error answering pre-checkout query", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error answering pre-checkout query");
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerShippingQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerShippingQuery.java
@@ -1,22 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.payments.ShippingOption;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerShippingQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerShippingQuery.java
@@ -85,16 +85,6 @@ public class AnswerShippingQuery extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error answering shipping query", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error answering shipping query");
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessage.java
@@ -1,25 +1,14 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.MessageId;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessage.java
@@ -128,17 +128,7 @@ public class CopyMessage extends BotApiMethod<MessageId> {
 
     @Override
     public MessageId deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<MessageId> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<MessageId>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error copying message", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error copying message");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessage.java
@@ -83,16 +83,6 @@ public class ForwardMessage extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error forwarding message", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error forwarding message");
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessage.java
@@ -1,22 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetFile.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetFile.java
@@ -58,16 +58,8 @@ public class GetFile extends BotApiMethod<File> {
 
     @Override
     public File deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<File> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<File>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting file", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+
+        return deserializeResponseDefault(answer,"Error getting file");
+
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetFile.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetFile.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetMe.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetMe.java
@@ -36,18 +36,7 @@ public class GetMe extends BotApiMethod<User> {
 
     @Override
     public User deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<User> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<User>>() {
-                    });
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting me", result);
-            }
-        } catch (IOException e2) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e2);
-        }
+        return deserializeResponseDefault(answer, "Error getting me");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetMe.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetMe.java
@@ -1,18 +1,9 @@
 package org.telegram.telegrambots.meta.api.methods;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.User;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetUserProfilePhotos.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetUserProfilePhotos.java
@@ -60,17 +60,7 @@ public class GetUserProfilePhotos extends BotApiMethod<UserProfilePhotos> {
 
     @Override
     public UserProfilePhotos deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<UserProfilePhotos> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<UserProfilePhotos>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting user profile photos", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error getting user profile photos");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetUserProfilePhotos.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/GetUserProfilePhotos.java
@@ -1,23 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.UserProfilePhotos;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethod.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethod.java
@@ -27,6 +27,7 @@ public abstract class PartialBotApiMethod<T extends Serializable> implements Val
     public abstract T deserializeResponse(String answer) throws TelegramApiRequestException;
 
     /**
+     * @author Timur Sergeevich
      * Deserialize a json answer to the response type to a method
      * @param answer Json answer received
      * @param exceptionMessage message to exception if result false

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethod.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethod.java
@@ -3,10 +3,8 @@ package org.telegram.telegrambots.meta.api.methods;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.telegram.telegrambots.meta.api.interfaces.Validable;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
-import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 
 import java.io.IOException;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethod.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethod.java
@@ -1,11 +1,15 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.telegram.telegrambots.meta.api.interfaces.Validable;
+import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 /**
@@ -23,4 +27,26 @@ public abstract class PartialBotApiMethod<T extends Serializable> implements Val
      * @return Answer for the method
      */
     public abstract T deserializeResponse(String answer) throws TelegramApiRequestException;
+
+    /**
+     * Deserialize a json answer to the response type to a method
+     * @param answer Json answer received
+     * @param exceptionMessage message to exception if result false
+     * @return Answer for the method
+     */
+    public T deserializeResponseDefault(String answer, String exceptionMessage) throws TelegramApiRequestException{
+
+        try {
+            ApiResponse<T> result = OBJECT_MAPPER.readValue(answer,
+                    new TypeReference<ApiResponse<T>>(){});
+            if (result.getOk()) {
+                return result.getResult();
+            } else {
+                throw new TelegramApiRequestException(exceptionMessage, result);
+            }
+        } catch (IOException e) {
+            throw new TelegramApiRequestException("Unable to deserialize response", e);
+        }
+
+    }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/SetPassportDataErrors.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/SetPassportDataErrors.java
@@ -1,22 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.passport.dataerror.PassportElementError;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/SetPassportDataErrors.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/SetPassportDataErrors.java
@@ -54,17 +54,7 @@ public class SetPassportDataErrors extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting passport data errors", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error setting passport data errors");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/StopMessageLiveLocation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/StopMessageLiveLocation.java
@@ -2,13 +2,7 @@ package org.telegram.telegrambots.meta.api.methods;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/adminrights/GetMyDefaultAdministratorRights.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/adminrights/GetMyDefaultAdministratorRights.java
@@ -1,15 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.adminrights;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.adminrights.ChatAdministratorRights;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/adminrights/GetMyDefaultAdministratorRights.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/adminrights/GetMyDefaultAdministratorRights.java
@@ -46,17 +46,7 @@ public class GetMyDefaultAdministratorRights extends BotApiMethod<ChatAdministra
 
     @Override
     public ChatAdministratorRights deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ChatAdministratorRights> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ChatAdministratorRights>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting default administrator rights", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error getting default administrator rights");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/adminrights/SetMyDefaultAdministratorRights.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/adminrights/SetMyDefaultAdministratorRights.java
@@ -54,17 +54,7 @@ public class SetMyDefaultAdministratorRights extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting default administrator rights", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error setting default administrator rights");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/adminrights/SetMyDefaultAdministratorRights.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/adminrights/SetMyDefaultAdministratorRights.java
@@ -1,16 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.adminrights;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.adminrights.ChatAdministratorRights;
-import org.telegram.telegrambots.meta.api.objects.commands.scope.BotCommandScope;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/DeleteMyCommands.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/DeleteMyCommands.java
@@ -1,21 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.commands;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.commands.scope.BotCommandScope;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/DeleteMyCommands.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/DeleteMyCommands.java
@@ -60,17 +60,7 @@ public class DeleteMyCommands extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error deleting commands", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error deleting commands");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/GetMyCommands.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/GetMyCommands.java
@@ -61,17 +61,7 @@ public class GetMyCommands extends BotApiMethod<ArrayList<BotCommand>> {
 
     @Override
     public ArrayList<BotCommand> deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ArrayList<BotCommand>> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ArrayList<BotCommand>>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending commands", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending commands");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/GetMyCommands.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/GetMyCommands.java
@@ -1,22 +1,13 @@
 package org.telegram.telegrambots.meta.api.methods.commands;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.commands.BotCommand;
 import org.telegram.telegrambots.meta.api.objects.commands.scope.BotCommandScope;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/SetMyCommands.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/SetMyCommands.java
@@ -72,17 +72,7 @@ public class SetMyCommands extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending commands", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending commands");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/SetMyCommands.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/commands/SetMyCommands.java
@@ -1,24 +1,13 @@
 package org.telegram.telegrambots.meta.api.methods.commands;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.commands.BotCommand;
 import org.telegram.telegrambots.meta.api.objects.commands.scope.BotCommandScope;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/games/GetGameHighScores.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/games/GetGameHighScores.java
@@ -83,17 +83,7 @@ public class GetGameHighScores extends BotApiMethod<ArrayList<GameHighScore>> {
 
     @Override
     public ArrayList<GameHighScore> deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ArrayList<GameHighScore>> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ArrayList<GameHighScore>>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting game high scores", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error getting game high scores");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/games/GetGameHighScores.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/games/GetGameHighScores.java
@@ -17,24 +17,12 @@
 package org.telegram.telegrambots.meta.api.methods.games;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.games.GameHighScore;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/games/SetGameScore.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/games/SetGameScore.java
@@ -19,19 +19,10 @@ package org.telegram.telegrambots.meta.api.methods.games;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
+import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/ApproveChatJoinRequest.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/ApproveChatJoinRequest.java
@@ -44,17 +44,7 @@ public class ApproveChatJoinRequest extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error approving chat join request", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error approving chat join request");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/ApproveChatJoinRequest.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/ApproveChatJoinRequest.java
@@ -1,14 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/BanChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/BanChatMember.java
@@ -92,17 +92,7 @@ public class BanChatMember extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error kicking chat member", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error kicking chat member");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/BanChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/BanChatMember.java
@@ -2,22 +2,11 @@ package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/BanChatSenderChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/BanChatSenderChat.java
@@ -2,14 +2,11 @@ package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/BanChatSenderChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/BanChatSenderChat.java
@@ -73,17 +73,7 @@ public class BanChatSenderChat extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error banning chat sender", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error banning chat sender");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/CreateChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/CreateChatInviteLink.java
@@ -1,23 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.ChatInviteLink;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/CreateChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/CreateChatInviteLink.java
@@ -77,17 +77,7 @@ public class CreateChatInviteLink extends BotApiMethod<ChatInviteLink> {
 
     @Override
     public ChatInviteLink deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ChatInviteLink> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ChatInviteLink>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error creating invite link", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error creating invite link");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeclineChatJoinRequest.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeclineChatJoinRequest.java
@@ -1,14 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeclineChatJoinRequest.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeclineChatJoinRequest.java
@@ -44,17 +44,7 @@ public class DeclineChatJoinRequest extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error declining chat join request", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error declining chat join request");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeleteChatPhoto.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeleteChatPhoto.java
@@ -49,17 +49,7 @@ public class DeleteChatPhoto extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error deleting chat photo", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error deleting chat photo");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeleteChatPhoto.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeleteChatPhoto.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeleteChatStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeleteChatStickerSet.java
@@ -48,17 +48,7 @@ public class DeleteChatStickerSet extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error deleting chat sticker set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error deleting chat sticker set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeleteChatStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/DeleteChatStickerSet.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/EditChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/EditChatInviteLink.java
@@ -82,17 +82,7 @@ public class EditChatInviteLink extends BotApiMethod<ChatInviteLink> {
 
     @Override
     public ChatInviteLink deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ChatInviteLink> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ChatInviteLink>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error creating invite link", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error creating invite link");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/EditChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/EditChatInviteLink.java
@@ -1,24 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Strings;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.ChatInviteLink;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/ExportChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/ExportChatInviteLink.java
@@ -54,17 +54,7 @@ public class ExportChatInviteLink extends BotApiMethod<String> {
 
     @Override
     public String deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<String> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<String>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error exporting invite link", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error exporting invite link");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/ExportChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/ExportChatInviteLink.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChat.java
@@ -46,17 +46,7 @@ public class GetChat extends BotApiMethod<Chat> {
 
     @Override
     public Chat deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Chat> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Chat>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting chat", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error getting chat");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChat.java
@@ -1,22 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatAdministrators.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatAdministrators.java
@@ -51,17 +51,7 @@ public class GetChatAdministrators extends BotApiMethod<ArrayList<ChatMember>> {
 
     @Override
     public ArrayList<ChatMember> deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ArrayList<ChatMember>> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ArrayList<ChatMember>>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting chat administrators", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error getting chat administrators");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatAdministrators.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatAdministrators.java
@@ -1,22 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatMember.java
@@ -51,17 +51,7 @@ public class GetChatMember extends BotApiMethod<ChatMember> {
 
     @Override
     public ChatMember deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ChatMember> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ChatMember>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting chat member", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error getting chat member");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatMember.java
@@ -1,22 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatMemberCount.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatMemberCount.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatMemberCount.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/GetChatMemberCount.java
@@ -45,17 +45,7 @@ public class GetChatMemberCount extends BotApiMethod<Integer> {
 
     @Override
     public Integer deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Integer> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Integer>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting chat members count", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error getting chat members count");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/LeaveChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/LeaveChat.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/LeaveChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/LeaveChat.java
@@ -45,17 +45,7 @@ public class LeaveChat extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error leaving chat", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error leaving chat");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/PromoteChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/PromoteChatMember.java
@@ -1,22 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/PromoteChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/PromoteChatMember.java
@@ -99,18 +99,7 @@ public class PromoteChatMember extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>() {
-                    });
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error promoting chat member", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error promoting chat member");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RestrictChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RestrictChatMember.java
@@ -2,23 +2,12 @@ package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.ChatPermissions;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RestrictChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RestrictChatMember.java
@@ -92,17 +92,7 @@ public class RestrictChatMember extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error restricting chat member", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error restricting chat member");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RevokeChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RevokeChatInviteLink.java
@@ -58,17 +58,7 @@ public class RevokeChatInviteLink extends BotApiMethod<ChatInviteLink> {
 
     @Override
     public ChatInviteLink deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ChatInviteLink> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ChatInviteLink>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error creating invite link", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error creating invite link");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RevokeChatInviteLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/RevokeChatInviteLink.java
@@ -1,23 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Strings;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.ChatInviteLink;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatAdministratorCustomTitle.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatAdministratorCustomTitle.java
@@ -54,17 +54,7 @@ public class SetChatAdministratorCustomTitle extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting chat description", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error setting chat description");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatAdministratorCustomTitle.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatAdministratorCustomTitle.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatDescription.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatDescription.java
@@ -52,17 +52,7 @@ public class SetChatDescription extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting chat description", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error setting chat description");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatDescription.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatDescription.java
@@ -1,22 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatPermissions.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatPermissions.java
@@ -1,22 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.ChatPermissions;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatPermissions.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatPermissions.java
@@ -52,17 +52,7 @@ public class SetChatPermissions extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting chat description", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error setting chat description");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatPhoto.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatPhoto.java
@@ -46,17 +46,7 @@ public class SetChatPhoto extends PartialBotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting chat photo", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error setting chat photo");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatPhoto.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatPhoto.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatStickerSet.java
@@ -52,17 +52,7 @@ public class SetChatStickerSet extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting chat sticker set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error setting chat sticker set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatStickerSet.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatTitle.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatTitle.java
@@ -53,17 +53,7 @@ public class SetChatTitle extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting chat title", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error setting chat title");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatTitle.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatTitle.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/UnbanChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/UnbanChatMember.java
@@ -1,22 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/UnbanChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/UnbanChatMember.java
@@ -62,17 +62,7 @@ public class UnbanChatMember extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error unbanning chat member", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error unbanning chat member");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/unbanChatSenderChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/unbanChatSenderChat.java
@@ -1,14 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.groupadministration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/unbanChatSenderChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/unbanChatSenderChat.java
@@ -45,17 +45,7 @@ public class unbanChatSenderChat extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error unbanning chat sender", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error unbanning chat sender");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/menubutton/GetChatMenuButton.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/menubutton/GetChatMenuButton.java
@@ -51,16 +51,6 @@ public class GetChatMenuButton extends BotApiMethod<MenuButton> {
 
     @Override
     public MenuButton deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<MenuButton> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<MenuButton>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting chat menu button query", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error getting chat menu button query");
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/menubutton/GetChatMenuButton.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/menubutton/GetChatMenuButton.java
@@ -1,15 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.menubutton;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.menubutton.MenuButton;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/menubutton/SetChatMenuButton.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/menubutton/SetChatMenuButton.java
@@ -63,16 +63,6 @@ public class SetChatMenuButton extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting chat menu button query", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error setting chat menu button query");
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/menubutton/SetChatMenuButton.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/menubutton/SetChatMenuButton.java
@@ -1,17 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.menubutton;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
-import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResult;
 import org.telegram.telegrambots.meta.api.objects.menubutton.MenuButton;
-import org.telegram.telegrambots.meta.api.objects.webapp.SentWebAppMessage;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/PinChatMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/PinChatMessage.java
@@ -62,17 +62,7 @@ public class PinChatMessage extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error pinning chat message", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error pinning chat message");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/PinChatMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/PinChatMessage.java
@@ -1,22 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.pinnedmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinAllChatMessages.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinAllChatMessages.java
@@ -50,17 +50,7 @@ public class UnpinAllChatMessages extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error unpinning chat message", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error unpinning chat message");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinAllChatMessages.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinAllChatMessages.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.pinnedmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinChatMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinChatMessage.java
@@ -61,17 +61,7 @@ public class UnpinChatMessage extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error unpinning chat message", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error unpinning chat message");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinChatMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinChatMessage.java
@@ -1,22 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.pinnedmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/SendPoll.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/SendPoll.java
@@ -1,27 +1,15 @@
 package org.telegram.telegrambots.meta.api.methods.polls;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/SendPoll.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/SendPoll.java
@@ -124,18 +124,7 @@ public class SendPoll extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>() {
-                    });
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending poll", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending poll");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/StopPoll.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/StopPoll.java
@@ -52,17 +52,7 @@ public class StopPoll extends BotApiMethod<Poll> {
 
     @Override
     public Poll deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Poll> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Poll>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error stopping poll", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error stopping poll");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/StopPoll.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/StopPoll.java
@@ -1,22 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.polls;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.polls.Poll;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAnimation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAnimation.java
@@ -1,19 +1,7 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
@@ -21,7 +9,6 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAnimation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAnimation.java
@@ -99,17 +99,7 @@ public class SendAnimation extends PartialBotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending animation", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending animation");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAudio.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAudio.java
@@ -1,19 +1,7 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
@@ -21,7 +9,6 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAudio.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAudio.java
@@ -95,17 +95,7 @@ public class SendAudio extends PartialBotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending audio", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error sending audio");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendChatAction.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendChatAction.java
@@ -76,17 +76,7 @@ public class SendChatAction extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending chat action", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending chat action");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendChatAction.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendChatAction.java
@@ -2,22 +2,11 @@ package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.ActionType;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendContact.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendContact.java
@@ -87,17 +87,7 @@ public class SendContact extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending contact", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending contact");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendContact.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendContact.java
@@ -1,24 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDice.java
@@ -1,24 +1,13 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDice.java
@@ -91,17 +91,7 @@ public class SendDice extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending dice", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending dice");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDocument.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDocument.java
@@ -1,19 +1,7 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
@@ -21,7 +9,6 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDocument.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDocument.java
@@ -87,17 +87,7 @@ public class SendDocument extends PartialBotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending document", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error sending document");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendGame.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendGame.java
@@ -93,17 +93,7 @@ public class SendGame extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending game", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending game");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendGame.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendGame.java
@@ -18,24 +18,12 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendInvoice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendInvoice.java
@@ -172,17 +172,7 @@ public class SendInvoice extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending invoice", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error sending invoice");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendInvoice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendInvoice.java
@@ -1,27 +1,15 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Strings;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.payments.LabeledPrice;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendLocation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendLocation.java
@@ -106,17 +106,7 @@ public class SendLocation extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending location", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending location");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendLocation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendLocation.java
@@ -1,24 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMediaGroup.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMediaGroup.java
@@ -1,18 +1,8 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.media.InputMedia;
 import org.telegram.telegrambots.meta.api.objects.media.InputMediaAnimation;
@@ -21,7 +11,6 @@ import org.telegram.telegrambots.meta.api.objects.media.InputMediaDocument;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMediaGroup.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMediaGroup.java
@@ -76,18 +76,7 @@ public class SendMediaGroup extends PartialBotApiMethod<ArrayList<Message>> {
 
     @Override
     public ArrayList<Message> deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<ArrayList<Message>> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ArrayList<Message>>>() {
-                    });
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending media group", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending media group");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMessage.java
@@ -123,17 +123,7 @@ public class SendMessage extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending message", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending message");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMessage.java
@@ -1,27 +1,16 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.ParseMode;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPhoto.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPhoto.java
@@ -81,17 +81,7 @@ public class SendPhoto extends PartialBotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending photo", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending photo");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPhoto.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPhoto.java
@@ -1,19 +1,7 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
@@ -21,7 +9,6 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendSticker.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendSticker.java
@@ -1,24 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendSticker.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendSticker.java
@@ -69,17 +69,7 @@ public class SendSticker extends PartialBotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending sticker", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending sticker");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVenue.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVenue.java
@@ -101,17 +101,7 @@ public class SendVenue extends BotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending venue", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending venue");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVenue.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVenue.java
@@ -1,24 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideo.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideo.java
@@ -94,17 +94,7 @@ public class SendVideo extends PartialBotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending video", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending video");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideo.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideo.java
@@ -1,19 +1,7 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
@@ -21,7 +9,6 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideoNote.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideoNote.java
@@ -80,17 +80,7 @@ public class SendVideoNote extends PartialBotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending video note", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer,"Error sending video note");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideoNote.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideoNote.java
@@ -1,25 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVoice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVoice.java
@@ -79,17 +79,7 @@ public class SendVoice extends PartialBotApiMethod<Message> {
 
     @Override
     public Message deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Message> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Message>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error sending voice", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error sending voice");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVoice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVoice.java
@@ -1,19 +1,7 @@
 package org.telegram.telegrambots.meta.api.methods.send;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
@@ -21,7 +9,6 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/AddStickerToSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/AddStickerToSet.java
@@ -77,17 +77,7 @@ public class AddStickerToSet extends PartialBotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error creating new sticker set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error creating new sticker set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/AddStickerToSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/AddStickerToSet.java
@@ -1,23 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.stickers;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.stickers.MaskPosition;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/CreateNewStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/CreateNewStickerSet.java
@@ -1,23 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.stickers;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.stickers.MaskPosition;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/CreateNewStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/CreateNewStickerSet.java
@@ -90,17 +90,7 @@ public class CreateNewStickerSet extends PartialBotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error creating new sticker set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error creating new sticker set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/DeleteStickerFromSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/DeleteStickerFromSet.java
@@ -45,17 +45,7 @@ public class DeleteStickerFromSet extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error deleting sticker from set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error deleting sticker from set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/DeleteStickerFromSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/DeleteStickerFromSet.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.stickers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/GetStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/GetStickerSet.java
@@ -1,22 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.stickers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.stickers.StickerSet;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/GetStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/GetStickerSet.java
@@ -46,17 +46,7 @@ public class GetStickerSet extends BotApiMethod<StickerSet> {
 
     @Override
     public StickerSet deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<StickerSet> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<StickerSet>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting sticker set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error getting sticker set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerPositionInSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerPositionInSet.java
@@ -1,22 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.stickers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.sun.source.tree.BreakTree;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerPositionInSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerPositionInSet.java
@@ -2,6 +2,7 @@ package org.telegram.telegrambots.meta.api.methods.stickers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.sun.source.tree.BreakTree;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -49,17 +50,7 @@ public class SetStickerPositionInSet extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting sticker position in set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error setting sticker position in set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerSetThumb.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerSetThumb.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.stickers;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerSetThumb.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerSetThumb.java
@@ -63,17 +63,7 @@ public class SetStickerSetThumb extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting sticker thumb in set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error setting sticker thumb in set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/UploadStickerFile.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/UploadStickerFile.java
@@ -1,22 +1,11 @@
 package org.telegram.telegrambots.meta.api.methods.stickers;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/UploadStickerFile.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/UploadStickerFile.java
@@ -48,17 +48,7 @@ public class UploadStickerFile extends PartialBotApiMethod<File> {
 
     @Override
     public File deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<File> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<File>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error uploading sticker set", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error uploading sticker set");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/Close.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/Close.java
@@ -39,18 +39,7 @@ public class Close extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>() {
-                    });
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error closing", result);
-            }
-        } catch (IOException e2) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e2);
-        }
+        return deserializeResponseDefault(answer, "Error closing");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/Close.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/Close.java
@@ -1,18 +1,9 @@
 package org.telegram.telegrambots.meta.api.methods.updates;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/DeleteWebhook.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/DeleteWebhook.java
@@ -43,19 +43,8 @@ public class DeleteWebhook extends BotApiMethod<Boolean>{
     }
 
     @Override
-    public Boolean deserializeResponse(String answer) throws
-            TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error deleting webhook", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+    public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
+        return deserializeResponseDefault(answer, "Error deleting webhook");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/DeleteWebhook.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/DeleteWebhook.java
@@ -1,20 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.updates;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/GetUpdates.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/GetUpdates.java
@@ -82,19 +82,8 @@ public class GetUpdates extends BotApiMethod<ArrayList<Update>>{
     }
 
     @Override
-    public ArrayList<Update> deserializeResponse(String answer) throws
-            TelegramApiRequestException {
-        try {
-            ApiResponse<ArrayList<Update>> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<ArrayList<Update>>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting updates", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+    public ArrayList<Update> deserializeResponse(String answer) throws TelegramApiRequestException {
+        return deserializeResponseDefault(answer, "Error getting updates");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/GetUpdates.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/GetUpdates.java
@@ -1,22 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.updates;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/GetWebhookInfo.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/GetWebhookInfo.java
@@ -39,18 +39,7 @@ public class GetWebhookInfo extends BotApiMethod<WebhookInfo> {
 
     @Override
     public WebhookInfo deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<WebhookInfo> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<WebhookInfo>>() {
-                    });
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error getting webhook info", result);
-            }
-        } catch (IOException e2) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e2);
-        }
+        return deserializeResponseDefault(answer, "Error getting webhook info");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/GetWebhookInfo.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/GetWebhookInfo.java
@@ -1,19 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.updates;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.WebhookInfo;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/LogOut.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/LogOut.java
@@ -39,18 +39,7 @@ public class LogOut extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>() {
-                    });
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error logging out", result);
-            }
-        } catch (IOException e2) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e2);
-        }
+        return deserializeResponseDefault(answer, "Error logging out");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/LogOut.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/LogOut.java
@@ -1,18 +1,9 @@
 package org.telegram.telegrambots.meta.api.methods.updates;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/SetWebhook.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/SetWebhook.java
@@ -84,17 +84,7 @@ public class SetWebhook extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error setting webhook", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error setting webhook");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/SetWebhook.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/SetWebhook.java
@@ -1,24 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.updates;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/DeleteMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/DeleteMessage.java
@@ -1,21 +1,10 @@
 package org.telegram.telegrambots.meta.api.methods.updatingmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/DeleteMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/DeleteMessage.java
@@ -63,18 +63,7 @@ public class DeleteMessage extends BotApiMethod<Boolean> {
 
     @Override
     public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<Boolean> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<Boolean>>() {
-                    });
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error deleting message", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error deleting message");
     }
 
     @Override

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageCaption.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageCaption.java
@@ -2,14 +2,7 @@ package org.telegram.telegrambots.meta.api.methods.updatingmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageLiveLocation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageLiveLocation.java
@@ -2,14 +2,7 @@ package org.telegram.telegrambots.meta.api.methods.updatingmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageMedia.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageMedia.java
@@ -2,15 +2,7 @@ package org.telegram.telegrambots.meta.api.methods.updatingmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageReplyMarkup.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageReplyMarkup.java
@@ -2,13 +2,7 @@ package org.telegram.telegrambots.meta.api.methods.updatingmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.Message;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageText.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageText.java
@@ -2,15 +2,7 @@ package org.telegram.telegrambots.meta.api.methods.updatingmessages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.ParseMode;
 import org.telegram.telegrambots.meta.api.objects.ApiResponse;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/webapp/AnswerWebAppQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/webapp/AnswerWebAppQuery.java
@@ -1,17 +1,12 @@
 package org.telegram.telegrambots.meta.api.methods.webapp;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
 import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResult;
-import org.telegram.telegrambots.meta.api.objects.payments.ShippingOption;
 import org.telegram.telegrambots.meta.api.objects.webapp.SentWebAppMessage;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
-
-import java.io.IOException;
 
 /**
  * @author Ruben Bermudez

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/webapp/AnswerWebAppQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/webapp/AnswerWebAppQuery.java
@@ -59,16 +59,6 @@ public class AnswerWebAppQuery  extends BotApiMethod<SentWebAppMessage> {
 
     @Override
     public SentWebAppMessage deserializeResponse(String answer) throws TelegramApiRequestException {
-        try {
-            ApiResponse<SentWebAppMessage> result = OBJECT_MAPPER.readValue(answer,
-                    new TypeReference<ApiResponse<SentWebAppMessage>>(){});
-            if (result.getOk()) {
-                return result.getResult();
-            } else {
-                throw new TelegramApiRequestException("Error answering web app query query", result);
-            }
-        } catch (IOException e) {
-            throw new TelegramApiRequestException("Unable to deserialize response", e);
-        }
+        return deserializeResponseDefault(answer, "Error answering web app query query");
     }
 }

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/TestDeserialization.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/TestDeserialization.java
@@ -27,6 +27,7 @@ import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMemberRestricte
 import org.telegram.telegrambots.meta.api.objects.commands.BotCommand;
 import org.telegram.telegrambots.meta.api.objects.inlinequery.ChosenInlineQuery;
 import org.telegram.telegrambots.meta.api.objects.inlinequery.InlineQuery;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -456,6 +457,18 @@ class TestDeserialization {
         assertNotNull(result.getParameters());
         assertEquals(Long.valueOf(12345), result.getParameters().getMigrateToChatId());
         assertEquals(Integer.valueOf(12), result.getParameters().getRetryAfter());
+    }
+
+    @Test
+    void TestDeserializeResponseDefault() {
+        try {
+            ArrayList<Update> updates = new GetUpdates().deserializeResponseDefault(TelegramBotsHelper.GetResponseWithError(), "Error getting updates");
+        } catch (TelegramApiRequestException exception) {
+            assertEquals("Error getting updates: [400] Error descriptions",exception.getMessage());
+        }
+
+
+
     }
 
     private void assertUpdate(Update update) {


### PR DESCRIPTION
Refactoring method implementation 
```java 
public abstract T deserializeResponse(String answer) throws TelegramApiRequestException;
```

Moved the common code to 
```java 
public T deserializeResponseDefault(String answer, String exceptionMessage) throws TelegramApiRequestException {
        try {
            ApiResponse<T> result = OBJECT_MAPPER.readValue(answer,
                    new TypeReference<ApiResponse<T>>(){});
            if (result.getOk()) {
                return result.getResult();
            } else {
                throw new TelegramApiRequestException(exceptionMessage, result);
            }
        } catch (IOException e) {
            throw new TelegramApiRequestException("Unable to deserialize response", e);
};
```
