### PR TITLE
Wiki: fixed checkGlobalFlags method in readme

### DIFF
--- a/TelegramBots.wiki/abilities/Advanced.md
+++ b/TelegramBots.wiki/abilities/Advanced.md
@@ -29,7 +29,7 @@ As an example, if you want to restrict the updates to photos only, then you may 
 ```java
   @Override
   public boolean checkGlobalFlags(Update update) {
-    return Flag.PHOTO;
+    return Flag.PHOTO.test(update);
   }
 ```
 


### PR DESCRIPTION
Hi! In reading the documentation, I noticed that Flag.PHOTO returns the Flag type, not bool, so i fixed wiki