### PR TITLE
Optimize imports for CreateInvoiceLink and SendInvoice classes

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/CreateInvoiceLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/CreateInvoiceLink.java
@@ -12,8 +12,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.Singular;
 import lombok.ToString;
-import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.payments.LabeledPrice;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
 import java.util.List;
@@ -31,7 +32,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CreateInvoiceLink extends BotApiMethodMessage {
+public class CreateInvoiceLink extends BotApiMethod<String> {
     public static final String PATH = "createInvoiceLink";
 
     public static final String TITLE_FIELD = "title";
@@ -60,7 +61,7 @@ public class CreateInvoiceLink extends BotApiMethodMessage {
     private String title; ///< Product name, 1-32 characters
     @JsonProperty(DESCRIPTION_FIELD)
     @NonNull
-    private String description; ///< 	Product description, 1-255 characters
+    private String description; ///< Product description, 1-255 characters
     @JsonProperty(PAYLOAD_FIELD)
     @NonNull
     private String payload; ///< Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
@@ -157,5 +158,10 @@ public class CreateInvoiceLink extends BotApiMethodMessage {
         if (suggestedTipAmounts != null && !suggestedTipAmounts.isEmpty() && suggestedTipAmounts.size() > 4) {
             throw new TelegramApiValidationException("No more that 4 suggested tips allowed", this);
         }
+    }
+
+    @Override
+    public String deserializeResponse(String answer) throws TelegramApiRequestException {
+        return deserializeResponse(answer, String.class);
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/CreateInvoiceLink.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/CreateInvoiceLink.java
@@ -1,7 +1,6 @@
 package org.telegram.telegrambots.meta.api.methods.invoices;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Strings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,15 +12,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.Singular;
 import lombok.ToString;
-import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
-import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.payments.LabeledPrice;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/SendInvoice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/SendInvoice.java
@@ -1,7 +1,6 @@
 package org.telegram.telegrambots.meta.api.methods.invoices;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Strings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,16 +13,11 @@ import lombok.Setter;
 import lombok.Singular;
 import lombok.ToString;
 import lombok.experimental.Tolerate;
-import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
-import org.telegram.telegrambots.meta.api.objects.ApiResponse;
-import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.payments.LabeledPrice;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/invoices/CreateInvoiceLinkTest.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/invoices/CreateInvoiceLinkTest.java
@@ -121,7 +121,6 @@ public class CreateInvoiceLinkTest {
 
         try {
             String link = createInvoiceLink.deserializeResponse(responseText);
-            System.out.println(link);
             assertEquals("https://t.me/testlink",link);
         } catch (TelegramApiRequestException e) {
             fail(e.getMessage());

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/invoices/CreateInvoiceLinkTest.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/invoices/CreateInvoiceLinkTest.java
@@ -2,15 +2,14 @@ package org.telegram.telegrambots.meta.api.methods.invoices;
 
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.payments.LabeledPrice;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Ruben Bermudez
@@ -109,6 +108,24 @@ public class CreateInvoiceLinkTest {
         createInvoiceLink.setSuggestedTipAmounts(Arrays.asList(1,2,3,4,5));
         Throwable thrown = assertThrows(TelegramApiValidationException.class, createInvoiceLink::validate);
         assertEquals("No more that 4 suggested tips allowed", thrown.getMessage());
+    }
+
+    @Test
+    public void testCreateInvoiceLinkDeserializeValidResponse(){
+        String responseText = "{\n" +
+                "    \"ok\": true,\n" +
+                "    \"result\": \"https://t.me/testlink\" \n" +
+                "}";
+
+        CreateInvoiceLink createInvoiceLink = createSendInvoiceObject();
+
+        try {
+            String link = createInvoiceLink.deserializeResponse(responseText);
+            System.out.println(link);
+            assertEquals("https://t.me/testlink",link);
+        } catch (TelegramApiRequestException e) {
+            fail(e.getMessage());
+        }
     }
 
     private CreateInvoiceLink createSendInvoiceObject() {


### PR DESCRIPTION
Fixed a bug in the deserializeResponse method of the CreateInvoiceLink class [issues #1115 ](https://github.com/rubenlagus/TelegramBots/issues/1115) And optimized imports for the CreateInvoiceLink and SendInvoice classes