### PR TITLE
fix - change mimeTypeVariable name in Animation object

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/games/Animation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/games/Animation.java
@@ -99,7 +99,7 @@ public class Animation implements BotApiObject {
      * MIME type of the file as defined by sender
      */
     @JsonProperty(MIMETYPE_FIELD)
-    private String mimetype;
+    private String mimeType;
     /**
      * Optional.
      * File size in bytes.


### PR DESCRIPTION
In other objects (Document, Audio, and others), the objects are called mimeType. It would be cool if everyone had the same name. For example, it makes it easier to use the mapstruct library