### PR TITLE
Exclude transitive vulnerable dependency from telegrambots module

### DIFF
--- a/telegrambots/pom.xml
+++ b/telegrambots/pom.xml
@@ -156,6 +156,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpcompontents.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
`telegrambots` module's dependency [**org.apache.httpcomponents.httpclient 4.5.13**](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.5.13) provides transitive vulnerable dependency [**commons-codec.commons-codec 1.11**](https://mvnrepository.com/artifact/commons-codec/commons-codec/1.11).

On this regard, IntelliJ highlights the following:

- [Cxeb68d52e-5509](https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/) 3.7 Exposure of Sensitive Information to an Unauthorized Actor

I checked if newer versions of `org.apache.httpcomponents.httpclient` upgraded that dependency but the [latest](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.5.14) is still exporting `commons-codec.commons-codec 1.11`.

Sorting this out will also fix the same issue for the modules `telegrambots-abilities`, `telegrambots-chat-session-bot`, `telegrambots-extensions`, and `telegrambots-spring-boot-starter`:

![image](https://user-images.githubusercontent.com/1816483/220450811-e43b809b-8cf3-4502-ae6c-08e3aec08838.png)
