### PR TITLE
Spring configuration

### DIFF
--- a/telegrambots-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/telegrambots-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,3 @@
+# Deprecated: To be removed when support for Spring Boot 2 is dropped
+# Replaced with file META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.telegram.telegrambots.starter.TelegramBotStarterConfiguration

--- a/telegrambots-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/telegrambots-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.telegram.telegrambots.starter.TelegramBotStarterConfiguration


### PR DESCRIPTION
Adding new spring boot config while keeping the old spring.factories. This should provide basic support for both Spring Boot 2 and 3. May still break if you use the wrong Jakarta versions.

> I still would suggest having `[META-INF/spring.factories]` for the mean time with a [META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports] side by side. This should already do the job to support both, Spring Boot 2 & 3 at the same time.
> 
> _Originally posted by @patbaumgartner in https://github.com/rubenlagus/TelegramBots/issues/1155#issuecomment-1445306344_
            