### PR TITLE
Change replies order logic

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/ReplyFlow.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/ReplyFlow.java
@@ -41,7 +41,7 @@ public class ReplyFlow extends Reply {
 
   @Override
   public Stream<Reply> stream() {
-    return Stream.concat(Stream.of(this), nextReplies.stream().flatMap(Reply::stream));
+    return Stream.concat(nextReplies.stream().flatMap(Reply::stream), Stream.of(this));
   }
 
   public static class ReplyFlowBuilder {


### PR DESCRIPTION
Hi!

Current version **telegrambots-abilities** doesn't support consistent dialogue with user.

If we create reply chain logic in ReplyFlow, every next reply will lie in List after parent reply.
It's logical, of course, but let's look at an example:

Let's say we have 3-state-reply-chain chat with user which will be built, for example, like this:

```
ReplyFlow.builder(dbContext)
                 .action((bot, update) -> bot.silent().send("Hi!", getChatId(update)))
                 .onlyIf(hasMessageWith("Hi"))
                 .next(ReplyFlow.builder(dbContext)
                                .action((bot, update) -> bot.silent().send("How are you?", getChatId(update)))
                                .next(ReplyFlow.builder(dbContext)
                                               .action((bot, update) -> bot.silent().send("Wow", getChatId(update)))
                                               .build())
                                .build())
                 .build();
```

In this example only one hand added condition for first state.
ReplyFlow also will add ID state check:

```
// From current version ReplyFlow:126
statefulConditions.add(0, upd -> {
        Long chatId = AbilityUtils.getChatId(upd);
        int stateId = db.<Long, Integer>getMap(STATES).getOrDefault(chatId, -1);
        return id == stateId;
      });
```

But if we enter the first state, bot won't wait user answer and send all messages from ReplyFlow chain.

i.e the dialogue will look like (U - User, B - Bot):
**U**: Hi, bot!
**B**: Hi!
**B**: How are you?
**B**: Wow

In common case if we don't have any rules for inner ReplyFlow's for various reasons, we will jump between states after one user message.
And the reason is that next reply lies after parent reply in common replies List in ```BaseAbilityBot```.