### PR TITLE
Add support for Spring Boot 3+

### DIFF
--- a/TelegramBots.wiki/FAQ.md
+++ b/TelegramBots.wiki/FAQ.md
@@ -346,3 +346,20 @@ After that your bot will look like:
   }
 ```
 Also you could just implement LongPollingBot or WebHookBot interfaces. All this bots will be registered in context and connected to Telegram api.
+
+In addition, you may use @AfterBotRegistration annotation on one of the methods inside your bot. This method will be called once
+after bot will be registered.
+
+```java
+import org.telegram.telegrambots.starter.AfterBotRegistration;
+
+@Component
+public class YourBotName extends TelegramLongPollingBot {
+    @AfterBotRegistration
+    public void postInit(){
+        //some code here
+    }
+    
+    //Bot body.
+}
+```

--- a/telegrambots-spring-boot-starter/README.md
+++ b/telegrambots-spring-boot-starter/README.md
@@ -56,3 +56,20 @@ After that your bot will look like:
   }
 ```
 Also you could just implement LongPollingBot or WebHookBot interfaces. All this bots will be registered in context and connected to Telegram api.
+
+In addition, you may use @AfterBotRegistration annotation on one of the methods inside your bot. This method will be called once
+after bot will be registered.
+
+```java
+import org.telegram.telegrambots.starter.AfterBotRegistration;
+
+@Component
+public class YourBotName extends TelegramLongPollingBot {
+    @AfterBotRegistration
+    public void postInit(){
+        //some code here
+    }
+    
+    //Bot body.
+}
+```

--- a/telegrambots-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/telegrambots-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.telegram.telegrambots.starter.TelegramBotStarterConfiguration


### PR DESCRIPTION
In accordance to [documentation on migration](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files) to SpringBoot 3 autoconfiguration file, from now should be placed slightly different.

Keeping both files (old and new) will keep support for versions older than Spring Boot 3 and will bring support of newer versions.

Also added documentation on @AfterBotRegistration annotation
