### PR TITLE
Remove commons-io dependency from main module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <lombok.version>1.18.28</lombok.version>
         <guava.version>32.0.0-jre</guava.version>
         <commons.version>3.12.0</commons.version>
+        <commonio.version>2.11.0</commonio.version>
     </properties>
 
     <dependencyManagement>

--- a/telegrambots-meta/pom.xml
+++ b/telegrambots-meta/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commonio.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/telegrambots/pom.xml
+++ b/telegrambots/pom.xml
@@ -72,7 +72,6 @@
 
         <glassfish.version>2.35</glassfish.version>
         <httpcompontents.version>4.5.13</httpcompontents.version>
-        <commonio.version>2.11.0</commonio.version>
     </properties>
 
     <dependencyManagement>
@@ -161,11 +160,6 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
             <version>${httpcompontents.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commonio.version}</version>
         </dependency>
 
         <dependency>

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/filedownloader/TelegramFileDownloader.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/filedownloader/TelegramFileDownloader.java
@@ -1,5 +1,7 @@
 package org.telegram.telegrambots.facilities.filedownloader;
 
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -15,7 +17,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
-import static org.apache.commons.io.FileUtils.copyInputStreamToFile;
 import static org.apache.http.HttpStatus.SC_OK;
 
 /**
@@ -146,7 +147,7 @@ public class TelegramFileDownloader {
     private CompletableFuture<java.io.File> getFileDownloadFuture(String url, java.io.File output) {
         return getFileDownloadStreamFuture(url).thenApply(stream -> {
             try {
-                copyInputStreamToFile(stream, output);
+                Files.copy(stream, output.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 return output;
             } catch (IOException e) {
                 throw new DownloadFileException("Error writing downloaded file", e);

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/TelegramFileDownloaderTest.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/TelegramFileDownloaderTest.java
@@ -1,5 +1,7 @@
 package org.telegram.telegrambots.test;
 
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -22,9 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.function.Supplier;
 
-import static java.nio.charset.Charset.defaultCharset;
-import static org.apache.commons.io.FileUtils.readFileToString;
-import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.apache.http.HttpVersion.HTTP_1_1;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -59,7 +58,7 @@ class TelegramFileDownloaderTest {
         when(httpResponseMock.getStatusLine()).thenReturn(new BasicStatusLine(HTTP_1_1, 200, "emptyString"));
         when(httpResponseMock.getEntity()).thenReturn(httpEntityMock);
 
-        when(httpEntityMock.getContent()).thenReturn(toInputStream("Some File Content", defaultCharset()));
+        when(httpEntityMock.getContent()).thenReturn(new ByteArrayInputStream("Some File Content".getBytes()));
         when(httpClientMock.execute(any(HttpUriRequest.class))).thenReturn(httpResponseMock);
 
         telegramFileDownloader = new TelegramFileDownloader(httpClientMock, tokenSupplierMock);
@@ -68,7 +67,7 @@ class TelegramFileDownloaderTest {
     @Test
     void testFileDownload() throws TelegramApiException, IOException {
         File returnFile = telegramFileDownloader.downloadFile("someFilePath");
-        String content = readFileToString(returnFile, defaultCharset());
+        String content = String.join("\n", Files.readAllLines(returnFile.toPath()));
 
         assertEquals("Some File Content", content);
     }
@@ -91,7 +90,7 @@ class TelegramFileDownloaderTest {
                 .times(1))
                 .onResult(any(), fileArgumentCaptor.capture());
 
-        String content = readFileToString(fileArgumentCaptor.getValue(), defaultCharset());
+        String content = String.join("\n", Files.readAllLines(fileArgumentCaptor.getValue().toPath()));
         assertEquals("Some File Content", content);
     }
 


### PR DESCRIPTION
I would like to propose removing commons-io dependency from main module.
Modern Java version offer similar methods to deal with files.