### PR TITLE
fix(sec): upgrade com.google.guava:guava to 32.0.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <slf4j.version>2.0.3</slf4j.version>
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
         <lombok.version>1.18.24</lombok.version>
-        <guava.version>31.1-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
         <commons.version>3.12.0</commons.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 31.1-jre
- [CVE-2023-2976](https://www.oscs1024.com/hd/CVE-2023-2976)


### What did I do？
Upgrade com.google.guava:guava from 31.1-jre to 32.0.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS