### PR TITLE
It's high time to migrate to HttpClient 5

### DIFF
--- a/telegrambots/pom.xml
+++ b/telegrambots/pom.xml
@@ -71,7 +71,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <glassfish.version>2.35</glassfish.version>
-        <httpcompontents.version>4.5.13</httpcompontents.version>
+        <httpcompontents.version>5.2.1</httpcompontents.version>
         <commonio.version>2.11.0</commonio.version>
     </properties>
 
@@ -153,13 +153,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpcompontents.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
             <version>${httpcompontents.version}</version>
         </dependency>
         <dependency>

--- a/telegrambots/src/main/java/org/telegram/telegrambots/Constants.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/Constants.java
@@ -1,11 +1,13 @@
 package org.telegram.telegrambots;
 
+import org.apache.hc.core5.util.Timeout;
+
 /**
  * @author Ruben Bermudez
  * @version 1.0
  * Constants needed for Telegram Bots API
  */
 public class Constants {
-    public static final int SOCKET_TIMEOUT = 75 * 1000;
+    public static final Timeout SOCKET_TIMEOUT = Timeout.ofSeconds(75);
     public static final String WEBHOOK_URL_PATH = "callback";
 }

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -3,15 +3,15 @@ package org.telegram.telegrambots.bots;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.Timeout;
 import org.telegram.telegrambots.facilities.TelegramHttpClientBuilder;
 import org.telegram.telegrambots.facilities.filedownloader.TelegramFileDownloader;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
@@ -102,9 +102,7 @@ public abstract class DefaultAbsSender extends AbsSender {
             this.requestConfig = configFromOptions;
         } else {
             this.requestConfig = RequestConfig.copy(RequestConfig.custom().build())
-                    .setSocketTimeout(SOCKET_TIMEOUT)
-                    .setConnectTimeout(SOCKET_TIMEOUT)
-                    .setConnectionRequestTimeout(SOCKET_TIMEOUT).build();
+                    .setConnectionRequestTimeout(Timeout.ofSeconds(SOCKET_TIMEOUT)).build();
         }
     }
 
@@ -1146,9 +1144,7 @@ public abstract class DefaultAbsSender extends AbsSender {
     }
 
     private String sendHttpPostRequest(HttpPost httppost) throws IOException {
-        try (CloseableHttpResponse response = httpClient.execute(httppost, options.getHttpContext())) {
-            return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-        }
+        return httpClient.execute(httppost, options.getHttpContext(), response -> EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8));
     }
 
     private HttpPost configuredHttpPost(String url) {

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -11,7 +11,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.util.Timeout;
 import org.telegram.telegrambots.facilities.TelegramHttpClientBuilder;
 import org.telegram.telegrambots.facilities.filedownloader.TelegramFileDownloader;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
@@ -102,7 +101,7 @@ public abstract class DefaultAbsSender extends AbsSender {
             this.requestConfig = configFromOptions;
         } else {
             this.requestConfig = RequestConfig.copy(RequestConfig.custom().build())
-                    .setConnectionRequestTimeout(Timeout.ofSeconds(SOCKET_TIMEOUT)).build();
+                    .setConnectionRequestTimeout(SOCKET_TIMEOUT).build();
         }
     }
 

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultBotOptions.java
@@ -1,8 +1,8 @@
 package org.telegram.telegrambots.bots;
 
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.telegram.telegrambots.meta.ApiConstants;
 import org.telegram.telegrambots.meta.generics.BotOptions;
 import org.telegram.telegrambots.meta.generics.BackOff;

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/TelegramHttpClientBuilder.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/TelegramHttpClientBuilder.java
@@ -10,7 +10,6 @@ import org.apache.hc.core5.http.config.Registry;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.TimeValue;
-import org.apache.hc.core5.util.Timeout;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.facilities.proxysocketfactorys.HttpConnectionSocketFactory;
 import org.telegram.telegrambots.facilities.proxysocketfactorys.HttpSSLConnectionSocketFactory;
@@ -51,8 +50,8 @@ public class TelegramHttpClientBuilder {
 
         ConnectionConfig connectionConfig = ConnectionConfig.custom()
                 .setTimeToLive(TimeValue.ofSeconds(70))
-                .setSocketTimeout(Timeout.ofSeconds(SOCKET_TIMEOUT))
-                .setConnectTimeout(Timeout.ofSeconds(SOCKET_TIMEOUT))
+                .setSocketTimeout(SOCKET_TIMEOUT)
+                .setConnectTimeout(SOCKET_TIMEOUT)
                 .build();
 
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(registry);

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/filedownloader/TelegramFileDownloader.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/filedownloader/TelegramFileDownloader.java
@@ -159,7 +159,7 @@ public class TelegramFileDownloader {
 
     private CompletableFuture<InputStream> getFileDownloadStreamFuture(final String url) {
         return CompletableFuture.supplyAsync(() -> {
-            try (ClassicHttpResponse response = httpClient.execute(new HttpGet(url), httpResponse -> httpResponse)) {
+            try (ClassicHttpResponse response = httpClient.executeOpen(null, new HttpGet(url), null)) {
                 final int statusCode = response.getCode();
                 if (statusCode == SC_OK) {
                     return new ByteArrayInputStream(EntityUtils.toByteArray(response.getEntity()));

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/filedownloader/TelegramFileDownloader.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/filedownloader/TelegramFileDownloader.java
@@ -172,7 +172,6 @@ public class TelegramFileDownloader {
                         @Override
                         public void close() throws IOException {
                             response.close();
-                            super.close();
                         }
                     };
                 } else {

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/proxysocketfactorys/HttpConnectionSocketFactory.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/proxysocketfactorys/HttpConnectionSocketFactory.java
@@ -1,8 +1,9 @@
 package org.telegram.telegrambots.facilities.proxysocketfactorys;
 
-import org.apache.http.HttpHost;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.TimeValue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -11,7 +12,7 @@ import java.net.Socket;
 
 public class HttpConnectionSocketFactory extends PlainConnectionSocketFactory {
     @Override
-    public Socket createSocket(final HttpContext context) throws IOException {
+    public Socket createSocket(final HttpContext context) {
         InetSocketAddress socketAddress = (InetSocketAddress) context.getAttribute("socketAddress");
         Proxy proxy = new Proxy(Proxy.Type.HTTP, socketAddress);
         return new Socket(proxy);
@@ -19,7 +20,7 @@ public class HttpConnectionSocketFactory extends PlainConnectionSocketFactory {
 
     @Override
     public Socket connectSocket(
-            int connectTimeout,
+            TimeValue connectTimeout,
             Socket socket,
             HttpHost host,
             InetSocketAddress remoteAddress,

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/proxysocketfactorys/HttpSSLConnectionSocketFactory.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/proxysocketfactorys/HttpSSLConnectionSocketFactory.java
@@ -1,9 +1,10 @@
 package org.telegram.telegrambots.facilities.proxysocketfactorys;
 
-import org.apache.http.HttpHost;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.TimeValue;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -18,7 +19,7 @@ public class HttpSSLConnectionSocketFactory extends SSLConnectionSocketFactory {
     }
 
     @Override
-    public Socket createSocket(final HttpContext context) throws IOException {
+    public Socket createSocket(final HttpContext context) {
         InetSocketAddress socketAddress = (InetSocketAddress) context.getAttribute("socketAddress");
         Proxy proxy = new Proxy(Proxy.Type.HTTP, socketAddress);
         return new Socket(proxy);
@@ -26,7 +27,7 @@ public class HttpSSLConnectionSocketFactory extends SSLConnectionSocketFactory {
 
     @Override
     public Socket connectSocket(
-            int connectTimeout,
+            TimeValue connectTimeout,
             Socket socket,
             HttpHost host,
             InetSocketAddress remoteAddress,

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/proxysocketfactorys/SocksConnectionSocketFactory.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/proxysocketfactorys/SocksConnectionSocketFactory.java
@@ -1,9 +1,10 @@
 package org.telegram.telegrambots.facilities.proxysocketfactorys;
 
 
-import org.apache.http.HttpHost;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.TimeValue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -21,7 +22,7 @@ public class SocksConnectionSocketFactory extends PlainConnectionSocketFactory {
 
     @Override
     public Socket connectSocket(
-            int connectTimeout,
+            TimeValue connectTimeout,
             Socket socket,
             HttpHost host,
             InetSocketAddress remoteAddress,

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/proxysocketfactorys/SocksSSLConnectionSocketFactory.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/proxysocketfactorys/SocksSSLConnectionSocketFactory.java
@@ -1,9 +1,10 @@
 package org.telegram.telegrambots.facilities.proxysocketfactorys;
 
-import org.apache.http.HttpHost;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.TimeValue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -28,7 +29,7 @@ public class SocksSSLConnectionSocketFactory extends SSLConnectionSocketFactory 
 
     @Override
     public Socket connectSocket(
-            int connectTimeout,
+            TimeValue connectTimeout,
             Socket socket,
             HttpHost host,
             InetSocketAddress remoteAddress,

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
@@ -250,7 +250,7 @@ public class DefaultBotSession implements BotSession {
             httpPost.setConfig(requestConfig);
             httpPost.setEntity(new StringEntity(objectMapper.writeValueAsString(request), ContentType.APPLICATION_JSON));
 
-            try (ClassicHttpResponse response = httpclient.execute(httpPost, options.getHttpContext(), httpResponse -> httpResponse)) {
+            try (ClassicHttpResponse response = httpclient.executeOpen(null, httpPost, options.getHttpContext())) {
                 String responseContent = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 
                 if (response.getCode() >= 500) {

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
@@ -9,7 +9,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
@@ -165,7 +164,7 @@ public class DefaultBotSession implements BotSession {
 
             if (requestConfig == null) {
                 requestConfig = RequestConfig.copy(RequestConfig.custom().build())
-                        .setConnectionRequestTimeout(Timeout.ofSeconds(SOCKET_TIMEOUT)).build();
+                        .setConnectionRequestTimeout(SOCKET_TIMEOUT).build();
             }
 
             super.start();

--- a/telegrambots/src/main/java/org/telegram/telegrambots/util/WebhookUtils.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/util/WebhookUtils.java
@@ -10,7 +10,6 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.util.Timeout;
 import org.telegram.telegrambots.Constants;
 import org.telegram.telegrambots.bots.DefaultAbsSender;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
@@ -54,7 +53,7 @@ public final class WebhookUtils {
             RequestConfig requestConfig = botOptions.getRequestConfig();
             if (requestConfig == null) {
                 requestConfig = RequestConfig.copy(RequestConfig.custom().build())
-                        .setConnectionRequestTimeout(Timeout.ofSeconds(SOCKET_TIMEOUT)).build();
+                        .setConnectionRequestTimeout(SOCKET_TIMEOUT).build();
             }
 
             HttpPost httppost = new HttpPost(requestUrl);

--- a/telegrambots/src/main/java/org/telegram/telegrambots/util/WebhookUtils.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/util/WebhookUtils.java
@@ -3,14 +3,14 @@ package org.telegram.telegrambots.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.util.Timeout;
 import org.telegram.telegrambots.Constants;
 import org.telegram.telegrambots.bots.DefaultAbsSender;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
@@ -28,109 +28,105 @@ import java.nio.charset.StandardCharsets;
 import static org.telegram.telegrambots.Constants.SOCKET_TIMEOUT;
 
 public final class WebhookUtils {
-  private static final ContentType TEXT_PLAIN_CONTENT_TYPE = ContentType.create("text/plain", StandardCharsets.UTF_8);
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ContentType TEXT_PLAIN_CONTENT_TYPE = ContentType.create("text/plain", StandardCharsets.UTF_8);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
-  private WebhookUtils() {
+    private WebhookUtils() {
 
-  }
+    }
 
-  /**
-   * Set webhook address to receive updates
-   * @param bot Bot to set the webhook to
-   * @param setWebhook SetSebhook object with webhook information
-   * @throws TelegramApiRequestException If any issue executing the request
-   *
-   * @apiNote Telegram API parameters will be taken only from SetWebhook object
-   * @apiNote Bot options will be fetched from Bot to set up the HTTP connection
-   */
-  public static void setWebhook(DefaultAbsSender bot, WebhookBot webhookBot, SetWebhook setWebhook) throws TelegramApiException {
-    setWebhook.validate();
+    /**
+     * Set webhook address to receive updates
+     *
+     * @param bot        Bot to set the webhook to
+     * @param setWebhook SetSebhook object with webhook information
+     * @throws TelegramApiRequestException If any issue executing the request
+     * @apiNote Telegram API parameters will be taken only from SetWebhook object
+     * @apiNote Bot options will be fetched from Bot to set up the HTTP connection
+     */
+    public static void setWebhook(DefaultAbsSender bot, WebhookBot webhookBot, SetWebhook setWebhook) throws TelegramApiException {
+        setWebhook.validate();
 
-    DefaultBotOptions botOptions = bot.getOptions();
-    try (CloseableHttpClient httpclient = TelegramHttpClientBuilder.build(botOptions)) {
-      String requestUrl = bot.getBaseUrl() + SetWebhook.PATH;
+        DefaultBotOptions botOptions = bot.getOptions();
+        try (CloseableHttpClient httpclient = TelegramHttpClientBuilder.build(botOptions)) {
+            String requestUrl = bot.getBaseUrl() + SetWebhook.PATH;
 
-      RequestConfig requestConfig = botOptions.getRequestConfig();
-      if (requestConfig == null) {
-        requestConfig = RequestConfig.copy(RequestConfig.custom().build())
-                .setSocketTimeout(SOCKET_TIMEOUT)
-                .setConnectTimeout(SOCKET_TIMEOUT)
-                .setConnectionRequestTimeout(SOCKET_TIMEOUT).build();
-      }
+            RequestConfig requestConfig = botOptions.getRequestConfig();
+            if (requestConfig == null) {
+                requestConfig = RequestConfig.copy(RequestConfig.custom().build())
+                        .setConnectionRequestTimeout(Timeout.ofSeconds(SOCKET_TIMEOUT)).build();
+            }
 
-      HttpPost httppost = new HttpPost(requestUrl);
-      httppost.setConfig(requestConfig);
-      MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-      builder.addTextBody(SetWebhook.URL_FIELD, getBotUrl(setWebhook, webhookBot), TEXT_PLAIN_CONTENT_TYPE);
-      if (setWebhook.getMaxConnections() != null) {
-        builder.addTextBody(SetWebhook.MAXCONNECTIONS_FIELD, setWebhook.getMaxConnections().toString(), TEXT_PLAIN_CONTENT_TYPE);
-      }
-      if (setWebhook.getAllowedUpdates() != null) {
-        builder.addTextBody(SetWebhook.ALLOWEDUPDATES_FIELD, objectMapper.writeValueAsString(setWebhook.getAllowedUpdates()), TEXT_PLAIN_CONTENT_TYPE);
-      }
-      if (setWebhook.getIpAddress() != null) {
-        builder.addTextBody(SetWebhook.IPADDRESS_FIELD, setWebhook.getIpAddress(), TEXT_PLAIN_CONTENT_TYPE);
-      }
-      if (setWebhook.getDropPendingUpdates() != null) {
-        builder.addTextBody(SetWebhook.DROPPENDINGUPDATES_FIELD, setWebhook.getDropPendingUpdates().toString(), TEXT_PLAIN_CONTENT_TYPE);
-      }
-      if (setWebhook.getSecretToken() != null) {
-        builder.addTextBody(SetWebhook.SECRETTOKEN_FIELD, setWebhook.getSecretToken(), TEXT_PLAIN_CONTENT_TYPE);
-      }
-      if (setWebhook.getCertificate() != null) {
-        InputFile webhookFile = setWebhook.getCertificate();
-        if (webhookFile.getNewMediaFile() != null) {
-          builder.addBinaryBody(SetWebhook.CERTIFICATE_FIELD, webhookFile.getNewMediaFile(), ContentType.TEXT_PLAIN, webhookFile.getMediaName());
-        } else if (webhookFile.getNewMediaStream() != null) {
-          builder.addBinaryBody(SetWebhook.CERTIFICATE_FIELD, webhookFile.getNewMediaStream(), ContentType.TEXT_PLAIN, webhookFile.getMediaName());
+            HttpPost httppost = new HttpPost(requestUrl);
+            httppost.setConfig(requestConfig);
+            MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+            builder.addTextBody(SetWebhook.URL_FIELD, getBotUrl(setWebhook, webhookBot), TEXT_PLAIN_CONTENT_TYPE);
+            if (setWebhook.getMaxConnections() != null) {
+                builder.addTextBody(SetWebhook.MAXCONNECTIONS_FIELD, setWebhook.getMaxConnections().toString(), TEXT_PLAIN_CONTENT_TYPE);
+            }
+            if (setWebhook.getAllowedUpdates() != null) {
+                builder.addTextBody(SetWebhook.ALLOWEDUPDATES_FIELD, objectMapper.writeValueAsString(setWebhook.getAllowedUpdates()), TEXT_PLAIN_CONTENT_TYPE);
+            }
+            if (setWebhook.getIpAddress() != null) {
+                builder.addTextBody(SetWebhook.IPADDRESS_FIELD, setWebhook.getIpAddress(), TEXT_PLAIN_CONTENT_TYPE);
+            }
+            if (setWebhook.getDropPendingUpdates() != null) {
+                builder.addTextBody(SetWebhook.DROPPENDINGUPDATES_FIELD, setWebhook.getDropPendingUpdates().toString(), TEXT_PLAIN_CONTENT_TYPE);
+            }
+            if (setWebhook.getSecretToken() != null) {
+                builder.addTextBody(SetWebhook.SECRETTOKEN_FIELD, setWebhook.getSecretToken(), TEXT_PLAIN_CONTENT_TYPE);
+            }
+            if (setWebhook.getCertificate() != null) {
+                InputFile webhookFile = setWebhook.getCertificate();
+                if (webhookFile.getNewMediaFile() != null) {
+                    builder.addBinaryBody(SetWebhook.CERTIFICATE_FIELD, webhookFile.getNewMediaFile(), ContentType.TEXT_PLAIN, webhookFile.getMediaName());
+                } else if (webhookFile.getNewMediaStream() != null) {
+                    builder.addBinaryBody(SetWebhook.CERTIFICATE_FIELD, webhookFile.getNewMediaStream(), ContentType.TEXT_PLAIN, webhookFile.getMediaName());
+                }
+            }
+
+            HttpEntity multipart = builder.build();
+            httppost.setEntity(multipart);
+            String responseContent = httpclient.execute(httppost, botOptions.getHttpContext(), httpResponse -> EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8));
+            Boolean result = setWebhook.deserializeResponse(responseContent);
+            if (!result) {
+                throw new TelegramApiRequestException("Error setting webhook:" + responseContent);
+            }
+        } catch (JsonProcessingException e) {
+            throw new TelegramApiRequestException("Error deserializing setWebhook method response", e);
+        } catch (IOException e) {
+            throw new TelegramApiRequestException("Error executing setWebook method", e);
         }
-      }
+    }
 
-      HttpEntity multipart = builder.build();
-      httppost.setEntity(multipart);
-      try (CloseableHttpResponse response = httpclient.execute(httppost, botOptions.getHttpContext())) {
-        String responseContent = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-        Boolean result = setWebhook.deserializeResponse(responseContent);
-        if (!result) {
-          throw new TelegramApiRequestException("Error setting webhook:" + responseContent);
+    public static void clearWebhook(DefaultAbsSender bot) throws TelegramApiRequestException {
+        try {
+            boolean result = bot.execute(new DeleteWebhook());
+            if (!result) {
+                throw new TelegramApiRequestException("Error removing old webhook");
+            }
+        } catch (TelegramApiException e) {
+            throw new TelegramApiRequestException("Error removing old webhook", e);
         }
-      }
-    } catch (JsonProcessingException e) {
-      throw new TelegramApiRequestException("Error deserializing setWebhook method response", e);
-    } catch (IOException e) {
-      throw new TelegramApiRequestException("Error executing setWebook method", e);
-    }
-  }
-
-  public static void clearWebhook(DefaultAbsSender bot) throws TelegramApiRequestException {
-    try {
-      boolean result = bot.execute(new DeleteWebhook());
-      if (!result) {
-        throw new TelegramApiRequestException("Error removing old webhook");
-      }
-    } catch (TelegramApiException e) {
-      throw new TelegramApiRequestException("Error removing old webhook", e);
-    }
-  }
-
-  private static String getBotUrl(SetWebhook setWebhook, WebhookBot webhookBot) {
-    String externalUrl = setWebhook.getUrl();
-    return getBotUrl(externalUrl, webhookBot.getBotPath());
-  }
-
-  private static String getBotUrl(String externalUrl, String botPath) {
-    if (!externalUrl.endsWith("/")) {
-      externalUrl += "/";
-    }
-    externalUrl += Constants.WEBHOOK_URL_PATH;
-    if (StringUtils.isNotEmpty(botPath)) {
-      if (!botPath.startsWith("/")) {
-        externalUrl += "/";
-      }
-      externalUrl += botPath;
     }
 
-    return externalUrl;
-  }
+    private static String getBotUrl(SetWebhook setWebhook, WebhookBot webhookBot) {
+        String externalUrl = setWebhook.getUrl();
+        return getBotUrl(externalUrl, webhookBot.getBotPath());
+    }
+
+    private static String getBotUrl(String externalUrl, String botPath) {
+        if (!externalUrl.endsWith("/")) {
+            externalUrl += "/";
+        }
+        externalUrl += Constants.WEBHOOK_URL_PATH;
+        if (StringUtils.isNotEmpty(botPath)) {
+            if (!botPath.startsWith("/")) {
+                externalUrl += "/";
+            }
+            externalUrl += botPath;
+        }
+
+        return externalUrl;
+    }
 }

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/TestDefaultBotSession.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/TestDefaultBotSession.java
@@ -1,12 +1,10 @@
 package org.telegram.telegrambots.test;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHttpResponse;
-import org.apache.http.message.BasicStatusLine;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,6 +25,7 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
+import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 import static org.mockito.ArgumentMatchers.any;
 
 /**
@@ -191,13 +190,11 @@ public class TestDefaultBotSession {
     }
 
     private DefaultBotSession getDefaultBotSession(LongPollingBot bot) throws IOException {
-        HttpResponse response = new BasicHttpResponse(new BasicStatusLine(
-                new ProtocolVersion("HTTP", 1, 1), 200, ""));
-        response.setStatusCode(200);
+        BasicClassicHttpResponse response = new BasicClassicHttpResponse(SC_OK);
         response.setEntity(new StringEntity("{}"));
 
         HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
-        Mockito.when(mockHttpClient.execute(any(HttpPost.class)))
+        Mockito.when(mockHttpClient.execute(any(HttpPost.class), any(HttpClientResponseHandler.class)))
                 .thenReturn(response);
         DefaultBotSession session = new DefaultBotSession();
         session.setCallback(bot);


### PR DESCRIPTION
# Why
- Apache HttpClient 4.5 provides transitive vulnerable dependency `maven:commons-codec:commons-codec:1.11`.
- New HttpClient 5 is out there and HttpClient 4.5 seems reached its end of life (last update - _Nov 30, 2022_).
# What changed
- `httpclient` and `httpmime` artifacts where replaced with `httpclient5` in `telegrambots/pom.xml`.
- Updated `org.telegram.telegrambots.facilities.TelegramHttpClientBuilder`. HttpClient 5 has changed the flow of `HttpClientConnectionManager` configuration.
- Business and Test classes were aligned with `org.apache.hc.*` package. Business logic was not changed.
- Avoided invokation of deprecated methods.
- `org.telegram.telegrambots.Constants#SOCKET_TIMEOUT` was migrated to `org.apache.hc.core5.util.Timeout`.
- Minor code refactoring. Changed line indentions in `org.telegram.telegrambots.util.WebhookUtils` to match project style.
# Validation
All unit tests passed. But I'm not aware whether they cover all test cases...
![image](https://github.com/rubenlagus/TelegramBots/assets/44120348/aa54da82-7899-46e4-8453-cdba3ab1ad52)
