### PR TITLE
Fixed incorrect Chat#profileBackgroundCustomEmojiId field type

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Chat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Chat.java
@@ -303,7 +303,7 @@ public class Chat implements BotApiObject {
      * Returned only in getChat.
      */
     @JsonProperty(PROFILE_BACKGROUND_CUSTOM_EMOJI_ID_FIELD)
-    private Boolean profileBackgroundCustomEmojiId;
+    private String profileBackgroundCustomEmojiId;
     /**
      * Optional.
      * True, if new chat members will have access to old messages; available only to chat administrators.


### PR DESCRIPTION
Changed Chat#profileBackgroundCustomEmojiId field type from 'Boolean' to 'String' (according to TelegramBotAPI Official Documentation).