### PR TITLE
Ability to rewrite bots session options on registering bots impl with custom session type

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cd telegrambots && mvn clean  install -Dgpg.skip -DskipTests

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-cd telegrambots && mvn clean  install -Dgpg.skip -DskipTests

--- a/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/updatesreceivers/DefaultBotSession.java
@@ -42,7 +42,7 @@ import static org.telegram.telegrambots.Constants.SOCKET_TIMEOUT;
 public class DefaultBotSession implements BotSession {
     private static final Logger log = LoggerFactory.getLogger(DefaultBotSession.class);
 
-    private AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicBoolean running = new AtomicBoolean(false);
 
     private final ConcurrentLinkedDeque<Update> receivedUpdates = new ConcurrentLinkedDeque<>();
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -52,7 +52,7 @@ public class DefaultBotSession implements BotSession {
     private LongPollingBot callback;
     private String token;
     private int lastReceivedUpdate = 0;
-    private DefaultBotOptions options;
+    protected DefaultBotOptions options;
     private UpdatesSupplier updatesSupplier;
 
     public DefaultBotSession() {


### PR DESCRIPTION
There is no ability to extend DefaultBotSession class and to set some custom options without access to private options field. For example For example ApiConstants.GETUPDATES_TIMEOUT = 50 is too much for bot.stop() usage and this httpclient timeout can be changed only with protected access for options fiels.

Example usage i want to have:


```
public class TgBotSession extends DefaultBotSession {
    public TgBotSession() {
        this.options = new DefaultBotOptions();
        this.options.setGetUpdatesTimeout(1);
    }

    @Override
    public void setOptions(BotOptions options) {
       // do nothing will ignore options instance from bot impl
    }
}
```
