### PR TITLE
Missing fields and constructor update for API 7.0

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/WriteAccessAllowed.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/WriteAccessAllowed.java
@@ -20,7 +20,7 @@ import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 @Getter
 @Setter
 @ToString
-@NoArgsConstructor
+@NoArgsConstructor(force = true)
 @AllArgsConstructor
 public class WriteAccessAllowed implements BotApiObject {
 

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethodTest.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethodTest.java
@@ -1,0 +1,43 @@
+package org.telegram.telegrambots.meta.api.methods;
+
+
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * @author Roman Bondar
+ */
+
+public class PartialBotApiMethodTest {
+
+    @Test
+    public void deserializeUpdateWithWriteAccessAllowedNotThrowApiException() throws IOException {
+
+        String answer = new String(Files.readAllBytes(Paths.get("src/test/resources/fixtures/update-with-write-access-allowed-for-webapp.json")));
+
+        PartialBotApiMethod method = new PartialBotApiMethod() {
+            @Override
+            public Serializable deserializeResponse(String answer) throws TelegramApiRequestException {
+                return deserializeResponseArray(answer, Update.class);
+            }
+
+            @Override
+            public String getMethod() {
+                return "method";
+            }
+        };
+
+        String finalAnswer = answer;
+        assertDoesNotThrow(() -> method.deserializeResponse(finalAnswer),
+                "deserializeResponse should not throw if write access allowed passed into it ");
+
+    }
+}

--- a/telegrambots-meta/src/test/resources/fixtures/update-with-write-access-allowed-for-webapp.json
+++ b/telegrambots-meta/src/test/resources/fixtures/update-with-write-access-allowed-for-webapp.json
@@ -1,0 +1,28 @@
+{
+  "ok": true,
+  "result": [
+    {
+      "update_id": 329421221,
+      "message": {
+        "message_id": 180,
+        "from": {
+          "id": 11111111,
+          "is_bot": false,
+          "first_name": "Alice Bob",
+          "username": "alicebob",
+          "language_code": "ru"
+        },
+        "chat": {
+          "id": 11111111,
+          "first_name": "Alice Bob",
+          "username": "alicebob",
+          "type": "private"
+        },
+        "date": 1707944280,
+        "write_access_allowed": {
+          "web_app_name": "alicebobshop"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Pull request to fix mismatch with latest API update:
- WriteAccessAllowed missing noarg constructor + test (related to [ #1312](https://github.com/rubenlagus/TelegramBots/issues/1312) )
- AllowUpdates added required fields 
- ReactionType for CustomEmoji matching boolean logic 
- MaybeInaccessibleMessage field type fix 
