### PR TITLE
Refactored verbose code constructs and QoL improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,18 @@ Just import add the library to your project with one of these options:
     <dependency>
         <groupId>org.telegram</groupId>
         <artifactId>telegrambots</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </dependency>
 ```
 
   2. Using Gradle: 
 
 ```gradle
-    implementation 'org.telegram:telegrambots:6.9.7.0'
+    implementation 'org.telegram:telegrambots:6.9.7.1'
 ```
 
-  3. Using Jitpack from [here](https://jitpack.io/#rubenlagus/TelegramBots/6.9.7.0)
-  4. Download the jar(including all dependencies) from [here](https://mvnrepository.com/artifact/org.telegram/telegrambots/6.9.7.0)
+  3. Using Jitpack from [here](https://jitpack.io/#rubenlagus/TelegramBots/6.9.7.1)
+  4. Download the jar(including all dependencies) from [here](https://mvnrepository.com/artifact/org.telegram/telegrambots/6.9.7.1)
 
 In order to use Long Polling mode, just create your own bot extending `org.telegram.telegrambots.bots.TelegramLongPollingBot`.
 

--- a/TelegramBots.wiki/Changelog.md
+++ b/TelegramBots.wiki/Changelog.md
@@ -1,5 +1,6 @@
 ### <a id="6.9.7.1"></a>6.9.7.1 ###
 1. Update Api version [7.1](https://core.telegram.org/bots/api-changelog#february-16-2024)
+2. Bug fixing: #1276 #1273 #1303 #1282 #1310 #1315 #1322 #1323
 
 ### <a id="6.9.7.0"></a>6.9.7.0 ###
 1. Update Api version [7.0](https://core.telegram.org/bots/api-changelog#december-29-2023)

--- a/TelegramBots.wiki/Changelog.md
+++ b/TelegramBots.wiki/Changelog.md
@@ -1,3 +1,6 @@
+### <a id="6.9.7.1"></a>6.9.7.1 ###
+1. Update Api version [7.1](https://core.telegram.org/bots/api-changelog#february-16-2024)
+
 ### <a id="6.9.7.0"></a>6.9.7.0 ###
 1. Update Api version [7.0](https://core.telegram.org/bots/api-changelog#december-29-2023)
 

--- a/TelegramBots.wiki/Changelog.md
+++ b/TelegramBots.wiki/Changelog.md
@@ -101,12 +101,12 @@
 4. Simplified methods to set files in methods. Only InputFile is available now (this class contains constructors for all the cases)  
 5. Locations now use Double instead of Float to avoid rounding.
 6. When using a TelegramApi for webhook usage, a Webhook instance has to be provided in constructor (i.e. DefaultWebhook class)
-6. When registering a Webhook Bot, a SetWebhook object must be provided.
-7. When using Webhook with Spring, extends class SpringWebhookBot instead of WebhookBot 
-8. New Async methods returning CompletableFutures (yes, we still have the existing callback methods)
-9. Added new Async methods for missing cases returning CompletableFutures. Like for sendAudio or sendVideo.
-10. No more Guice to define custom class
-11. Bug fixes: #795
+7. When registering a Webhook Bot, a SetWebhook object must be provided.
+8. When using Webhook with Spring, extends class SpringWebhookBot instead of WebhookBot 
+9. New Async methods returning CompletableFutures (yes, we still have the existing callback methods)
+10. Added new Async methods for missing cases returning CompletableFutures. Like for sendAudio or sendVideo.
+11. No more Guice to define custom class
+12. Bug fixes: #795
 
 **[[How to update to version 5.0.0|How-To-Update#5.0.0]]**
 

--- a/TelegramBots.wiki/Getting-Started.md
+++ b/TelegramBots.wiki/Getting-Started.md
@@ -11,13 +11,13 @@ First you need to acquire the library and add it to your project. There are seve
            <dependency>
               <groupId>org.telegram</groupId>
               <artifactId>telegrambots</artifactId>
-              <version>6.9.7.0</version>
+              <version>6.9.7.1</version>
            </dependency>
         ```
     * With **Gradle**:
     
         ```gradle
-          implementation 'org.telegram:telegrambots:6.9.7.0'
+          implementation 'org.telegram:telegrambots:6.9.7.1'
         ```
  
 2. Don't like the **Maven Central Repository**? It can also be grabbed from [Jitpack](https://jitpack.io/#rubenlagus/TelegramBots).

--- a/TelegramBots.wiki/How-To-Update.md
+++ b/TelegramBots.wiki/How-To-Update.md
@@ -155,7 +155,7 @@
     ApiContextInitializer.init();
     ```
 3. In `SentCallback`, update parameter types of `onResult` and `onError`. Inside those two method, you don't need to deserialize anything now, it comes already done.
-3. **Deprecated** (will be removed in next version):
+4. **Deprecated** (will be removed in next version):
     * `org.telegram.telegrambots.bots.BotOptions`. Use `org.telegram.telegrambots.bots.DefaultBotOptions` instead.
     * `getPersonal` from `AnswerInlineQuery`. Use `isPersonal` instead.
     * `FILEBASEURL` from `File`. Use `getFileUrl` instead.

--- a/TelegramBots.wiki/abilities/Simple-Example.md
+++ b/TelegramBots.wiki/abilities/Simple-Example.md
@@ -9,12 +9,12 @@ As with any Java project, you will need to set your dependencies.
    <dependency>
       <groupId>org.telegram</groupId>
       <artifactId>telegrambots-abilities</artifactId>
-      <version>6.9.7.0</version>
+      <version>6.9.7.1</version>
    </dependency>
 ```
 * **Gradle**
 ```gradle
-  implementation 'org.telegram:telegrambots-abilities:6.9.7.0'
+  implementation 'org.telegram:telegrambots-abilities:6.9.7.1'
 ```
 * [JitPack](https://jitpack.io/#rubenlagus/TelegramBots)
     

--- a/TelegramBots.wiki/abilities/Using-Replies.md
+++ b/TelegramBots.wiki/abilities/Using-Replies.md
@@ -12,7 +12,7 @@ public Reply sayYuckOnImage() {
   // getChatId is a public utility function in rg.telegram.abilitybots.api.util.AbilityUtils
   Consumer<Update> action = upd -> silent.send("Yuck", getChatId(upd)); 
   
-  return Reply.of(action, Flag.PHOTO)
+  return Reply.of(action, Flag.PHOTO);
 }
 ```
 
@@ -36,7 +36,7 @@ public Ability playWithMe() {
         // The signature of a reply is -> (Consumer<Update> action, Predicate<Update>... conditions)
         // So, we  first declare the action that takes an update (NOT A MESSAGECONTEXT) like the action above
         // The reason of that is that a reply can be so versatile depending on the message, context becomes an inefficient wrapping
-        .reply(upd -> {
+        .reply((abilityBot,upd) -> {
               // Prints to console
               System.out.println("I'm in a reply!");
               // Sends message

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.telegram</groupId>
     <artifactId>Bots</artifactId>
     <packaging>pom</packaging>
-    <version>6.9.7.0</version>
+    <version>6.9.7.1</version>
 
     <modules>
         <module>telegrambots</module>

--- a/telegrambots-abilities/README.md
+++ b/telegrambots-abilities/README.md
@@ -18,14 +18,14 @@ Usage
     <dependency>
         <groupId>org.telegram</groupId>
         <artifactId>telegrambots-abilities</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </dependency>
 ```
 
 **Gradle**
 
 ```gradle
-    implementation 'org.telegram:telegrambots-abilities:6.9.7.0'
+    implementation 'org.telegram:telegrambots-abilities:6.9.7.1'
 ```
 
 **JitPack** - [JitPack](https://jitpack.io/#rubenlagus/TelegramBots/v5.0.1)

--- a/telegrambots-abilities/pom.xml
+++ b/telegrambots-abilities/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </parent>
 
     <artifactId>telegrambots-abilities</artifactId>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots</artifactId>
-            <version>6.9.7.0</version>
+            <version>6.9.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/DefaultAbilities.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/bot/DefaultAbilities.java
@@ -167,7 +167,7 @@ public final class DefaultAbilities implements AbilityExtension {
 
           String commands = abilitiesPerPrivacy.asMap().entrySet().stream()
               .filter(entry -> privacy.compareTo(entry.getKey()) >= 0)
-              .sorted(comparing(Map.Entry::getKey))
+              .sorted(Map.Entry.comparingByKey())
               .map(entry ->
                   entry.getValue().stream()
                       .reduce(entry.getKey().toString(), (a, b) -> format("%s\n%s", a, b))

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBContext.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBContext.java
@@ -186,7 +186,7 @@ public class MapDBContext implements DBContext {
       else if (struct instanceof Atomic.Var<?>)
         return Pair.of(entry.getKey(), BackupVar.createVar(((Atomic.Var<?>) struct).get()));
       return Pair.of(entry.getKey(), struct);
-    }).collect(toMap(pair -> (String) pair.a(), Pair::b));
+    }).collect(toMap(Pair::a, Pair::b));
   }
 
   private void doRecover(Map<String, Object> backupData) {

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBContext.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBContext.java
@@ -134,12 +134,12 @@ public class MapDBContext implements DBContext {
     if (isNull(struct))
       throw new IllegalStateException(format("DB structure with name [%s] does not exist", name));
 
-    if (struct instanceof Set)
-      return format("%s - Set - %d", name, ((Set) struct).size());
-    else if (struct instanceof List)
-      return format("%s - List - %d", name, ((List) struct).size());
-    else if (struct instanceof Map)
-      return format("%s - Map - %d", name, ((Map) struct).size());
+    if (struct instanceof Set<?>)
+      return format("%s - Set - %d", name, ((Set<?>) struct).size());
+    else if (struct instanceof List<?>)
+      return format("%s - List - %d", name, ((List<?>) struct).size());
+    else if (struct instanceof Map<?, ?>)
+      return format("%s - Map - %d", name, ((Map<?, ?>) struct).size());
     else
       return format("%s - %s", name, struct.getClass().getSimpleName());
   }
@@ -153,10 +153,10 @@ public class MapDBContext implements DBContext {
   public void clear() {
     db.getAllNames().forEach(name -> {
       Object struct = db.get(name);
-      if (struct instanceof Collection)
-        ((Collection) struct).clear();
-      else if (struct instanceof Map)
-        ((Map) struct).clear();
+      if (struct instanceof Collection<?>)
+        ((Collection<?>) struct).clear();
+      else if (struct instanceof Map<?, ?>)
+        ((Map<?, ?>) struct).clear();
     });
     commit();
   }
@@ -177,14 +177,14 @@ public class MapDBContext implements DBContext {
   private Map<String, Object> localCopy() {
     return db.getAll().entrySet().stream().map(entry -> {
       Object struct = entry.getValue();
-      if (struct instanceof Set)
-        return Pair.of(entry.getKey(), newHashSet((Set) struct));
-      else if (struct instanceof List)
-        return Pair.of(entry.getKey(), newArrayList((List) struct));
-      else if (struct instanceof Map)
-        return Pair.of(entry.getKey(), new BackupMap((Map) struct));
-      else if (struct instanceof Atomic.Var)
-        return Pair.of(entry.getKey(), BackupVar.createVar(((Atomic.Var) struct).get()));
+      if (struct instanceof Set<?>)
+        return Pair.of(entry.getKey(), newHashSet((Set<?>) struct));
+      else if (struct instanceof List<?>)
+        return Pair.of(entry.getKey(), newArrayList((List<?>) struct));
+      else if (struct instanceof Map<?, ?>)
+        return Pair.of(entry.getKey(), new BackupMap<>((Map<?, ?>) struct));
+      else if (struct instanceof Atomic.Var<?>)
+        return Pair.of(entry.getKey(), BackupVar.createVar(((Atomic.Var<?>) struct).get()));
       return Pair.of(entry.getKey(), struct);
     }).collect(toMap(pair -> (String) pair.a(), Pair::b));
   }
@@ -192,17 +192,17 @@ public class MapDBContext implements DBContext {
   private void doRecover(Map<String, Object> backupData) {
     clear();
     backupData.forEach((name, value) -> {
-      if (value instanceof Set) {
-        Set entrySet = (Set) value;
+      if (value instanceof Set<?>) {
+        Set<?> entrySet = (Set<?>) value;
         getSet(name).addAll(entrySet);
-      } else if (value instanceof BackupMap) {
-        Map<Object, Object> entryMap = ((BackupMap) value).toMap();
+      } else if (value instanceof BackupMap<?, ?>) {
+        Map<Object, Object> entryMap = ((BackupMap<Object, Object>) value).toMap();
         getMap(name).putAll(entryMap);
-      } else if (value instanceof List) {
-        List entryList = (List) value;
+      } else if (value instanceof List<?>) {
+        List<?> entryList = (List<?>) value;
         getList(name).addAll(entryList);
-      } else if (value instanceof BackupVar) {
-        getVar(name).set(((BackupVar) value).var());
+      } else if (value instanceof BackupVar<?>) {
+        getVar(name).set(((BackupVar<?>) value).var());
       } else {
         log.error(format("Unable to identify object type during DB recovery, entry name: %s", name));
       }

--- a/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/ReplyFlow.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/objects/ReplyFlow.java
@@ -104,7 +104,7 @@ public class ReplyFlow extends Reply {
         action = (bot, upd) -> {};
 
       BiConsumer<BaseAbilityBot, Update> statefulAction;
-      if (nextReplies.size() > 0) {
+      if (!nextReplies.isEmpty()) {
         statefulAction = action.andThen((bot, upd) -> {
           Long chatId = AbilityUtils.getChatId(upd);
           db.<Long, Integer>getMap(STATES).put(chatId, id);

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ReplyFlowTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/ReplyFlowTest.java
@@ -195,17 +195,13 @@ public class ReplyFlowTest {
     public Ability replyFlowsWithAbility() {
       Reply replyWithVk = ReplyFlow.builder(db, 2)
           .enableStats("SECOND")
-          .action((bot, upd) -> {
-            silent.send("Second reply", upd.getMessage().getChatId());
-          })
+          .action((bot, upd) -> silent.send("Second reply", upd.getMessage().getChatId()))
           .onlyIf(hasMessageWith("two"))
           .build();
 
       Reply replyWithNickname = ReplyFlow.builder(db, 1)
           .enableStats("FIRST")
-          .action((bot, upd) -> {
-            silent.send("First reply", upd.getMessage().getChatId());
-          })
+          .action((bot, upd) -> silent.send("First reply", upd.getMessage().getChatId()))
           .onlyIf(hasMessageWith("one"))
           .next(replyWithVk)
           .build();

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/TestUtils.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/bot/TestUtils.java
@@ -34,7 +34,7 @@ public final class TestUtils {
     when(message.getText()).thenReturn(args);
     when(message.hasText()).thenReturn(true);
     when(message.isUserMessage()).thenReturn(true);
-    when(message.getChatId()).thenReturn((long) user.getId());
+    when(message.getChatId()).thenReturn(user.getId());
     when(update.getMessage()).thenReturn(message);
     return update;
   }

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/db/MapDBContextTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/db/MapDBContextTest.java
@@ -154,6 +154,6 @@ class MapDBContextTest {
     var.set(USER);
     db.commit();
     Var<User> changedVar = db.getVar(varName);
-    Assertions.assertEquals("MapDBVar{var=User(id=1, firstName=first, isBot=false, lastName=last, userName=username, languageCode=null, canJoinGroups=false, canReadAllGroupMessages=false, supportInlineQueries=false, isPremium=false, addedToAttachmentMenu=false)}", ((MapDBVar) (changedVar)).toString());
+    Assertions.assertEquals("MapDBVar{var=User(id=1, firstName=first, isBot=false, lastName=last, userName=username, languageCode=null, canJoinGroups=false, canReadAllGroupMessages=false, supportInlineQueries=false, isPremium=false, addedToAttachmentMenu=false)}", ((MapDBVar<?>) (changedVar)).toString());
   }
 }

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/sender/SilentSenderTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/sender/SilentSenderTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
@@ -45,6 +46,7 @@ class SilentSenderTest {
 
     Optional execute = silent.execute(null);
 
+    assertTrue(execute.isPresent(), "Optional is empty");
     assertEquals(data, execute.get(), "Silent execution resulted in a different object");
   }
 

--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/sender/SilentSenderTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/sender/SilentSenderTest.java
@@ -34,7 +34,7 @@ class SilentSenderTest {
   void returnsEmptyOnError() throws TelegramApiException {
     when(sender.execute(any())).thenThrow(TelegramApiException.class);
 
-    Optional execute = silent.execute(null);
+    Optional<?> execute = silent.execute(null);
 
     assertFalse(execute.isPresent(), "Execution of a bot API method with execption results in a nonempty optional");
   }
@@ -44,7 +44,7 @@ class SilentSenderTest {
     String data = "data";
     when(sender.execute(any())).thenReturn(data);
 
-    Optional execute = silent.execute(null);
+    Optional<?> execute = silent.execute(null);
 
     assertTrue(execute.isPresent(), "Optional is empty");
     assertEquals(data, execute.get(), "Silent execution resulted in a different object");

--- a/telegrambots-chat-session-bot/README.md
+++ b/telegrambots-chat-session-bot/README.md
@@ -15,14 +15,14 @@ Usage
     <dependency>
         <groupId>org.telegram</groupId>
         <artifactId>telegrambots-chat-session-bot</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </dependency>
 ```
 
 **Gradle**
 
 ```gradle
-    implementation 'org.telegram:telegrambots-chat-session-bot:6.9.7.0'
+    implementation 'org.telegram:telegrambots-chat-session-bot:6.9.7.1'
 ```
 
 Motivation

--- a/telegrambots-chat-session-bot/pom.xml
+++ b/telegrambots-chat-session-bot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </parent>
 
     <artifactId>telegrambots-chat-session-bot</artifactId>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots</artifactId>
-            <version>6.9.7.0</version>
+            <version>6.9.7.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.shiro/shiro-core -->

--- a/telegrambots-extensions/README.md
+++ b/telegrambots-extensions/README.md
@@ -16,12 +16,12 @@ Just import add the library to your project with one of these options:
     <dependency>
         <groupId>org.telegram</groupId>
         <artifactId>telegrambotsextensions</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </dependency>
 ```
 
    2. Using Gradle:
 
 ```gradle
-    implementation 'org.telegram:telegrambotsextensions:6.9.7.0'
+    implementation 'org.telegram:telegrambotsextensions:6.9.7.1'
 ```

--- a/telegrambots-extensions/pom.xml
+++ b/telegrambots-extensions/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </parent>
 
     <artifactId>telegrambotsextensions</artifactId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots</artifactId>
-            <version>6.9.7.0</version>
+            <version>6.9.7.1</version>
         </dependency>
     </dependencies>
 

--- a/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/commands/helpCommand/HelpCommand.java
+++ b/telegrambots-extensions/src/main/java/org/telegram/telegrambots/extensions/bots/commandbot/commands/helpCommand/HelpCommand.java
@@ -60,7 +60,7 @@ public class HelpCommand extends ManCommand {
 	 * @return the extended Description or the toString() if IManCommand is not implemented
 	 */
 	public static String getManText(IBotCommand command) {
-		return IManCommand.class.isInstance(command) ? getManText((IManCommand) command) : command.toString();
+		return command instanceof IManCommand ? getManText((IManCommand) command) : command.toString();
 	}
 	
 	/**
@@ -91,7 +91,7 @@ public class HelpCommand extends ManCommand {
 	
 	@Override
 	public void execute(AbsSender absSender, User user, Chat chat, String[] arguments) {
-		if (ICommandRegistry.class.isInstance(absSender)) {
+		if (absSender instanceof ICommandRegistry) {
 			ICommandRegistry registry = (ICommandRegistry) absSender;
 			
 			if (arguments.length > 0) {

--- a/telegrambots-meta/pom.xml
+++ b/telegrambots-meta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </parent>
 
     <artifactId>telegrambots-meta</artifactId>

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerInlineQuery.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/AnswerInlineQuery.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.Singular;
 import lombok.ToString;
-import lombok.extern.jackson.Jacksonized;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodBoolean;
 import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResult;
 import org.telegram.telegrambots.meta.api.objects.inlinequery.result.InlineQueryResultsButton;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/PromoteChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/PromoteChatMember.java
@@ -44,9 +44,12 @@ public class PromoteChatMember extends BotApiMethodBoolean {
     private static final String CANPINMESSAGES_FIELD = "can_pin_messages";
     private static final String CANPROMOTEMEMBERS_FIELD = "can_promote_members";
     private static final String ISANONYMOUS_FIELD = "is_anonymous";
-    private static final String CANMANAGECHAT_FIELD = "can_manage_chat";
+    private static final String CAN_MANAGE_CHAT_FIELD = "can_manage_chat";
     private static final String CANMANAGEVIDEOCHATS_FIELD = "can_manage_video_chats";
     private static final String CANMANAGETOPICS_FIELD = "can_manage_topics";
+    private static final String CAN_POST_STORIES_FIELD = "can_post_stories";
+    private static final String CAN_EDIT_STORIES_FIELD = "can_edit_stories";
+    private static final String CAN_DELETE_STORIES_FIELD = "can_delete_stories";
 
     @JsonProperty(CHATID_FIELD)
     @NonNull
@@ -80,7 +83,7 @@ public class PromoteChatMember extends BotApiMethodBoolean {
      *
      * Implied by any other administrator privilege
      */
-    @JsonProperty(CANMANAGECHAT_FIELD)
+    @JsonProperty(CAN_MANAGE_CHAT_FIELD)
     private Boolean canManageChat;
     /**
      * Optional
@@ -94,6 +97,24 @@ public class PromoteChatMember extends BotApiMethodBoolean {
      */
     @JsonProperty(CANMANAGETOPICS_FIELD)
     private Boolean canManageTopics;
+    /**
+     * Optional
+     * True if the administrator can post stories to the chat
+     */
+    @JsonProperty(CAN_POST_STORIES_FIELD)
+    private Boolean canPostStories;
+    /**
+     * Optional
+     * True if the administrator can edit stories posted by other users
+     */
+    @JsonProperty(CAN_EDIT_STORIES_FIELD)
+    private Boolean canEditStories;
+    /**
+     * Optional
+     * True if the administrator can delete stories posted by other users
+     */
+    @JsonProperty(CAN_DELETE_STORIES_FIELD)
+    private Boolean canDeleteStories;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatTitle.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/SetChatTitle.java
@@ -13,8 +13,6 @@ import lombok.experimental.Tolerate;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodBoolean;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
-import java.util.List;
-
 /**
  * @author Ruben Bermudez
  * @version 3.1
@@ -49,9 +47,6 @@ public class SetChatTitle extends BotApiMethodBoolean {
         this.chatId = chatId.toString();
     }
 
-    private long[] otherUserIds;
-    private byte[] fileHashes;
-
     @Override
     public String getMethod() {
         return PATH;
@@ -74,24 +69,5 @@ public class SetChatTitle extends BotApiMethodBoolean {
             this.chatId = chatId.toString();
             return this;
         }
-
-        @Tolerate
-        public SetChatTitleBuilder ids(List<Byte> otherUserIds) {
-            this.otherUserIds = new long[otherUserIds.size()];
-            for (int i = 0; i < otherUserIds.size(); i++) {
-                this.otherUserIds[i] = otherUserIds.get(i);
-            }
-            return this;
-        }
-
-        @Tolerate
-        public SetChatTitleBuilder otherUserId(Long otherUserId) {
-            long[] newOtherUserIds = new long[this.otherUserIds.length + 1];
-            System.arraycopy(this.otherUserIds, 0, newOtherUserIds, 0, this.otherUserIds.length);
-            newOtherUserIds[newOtherUserIds.length - 1] = otherUserId;
-            this.otherUserIds = newOtherUserIds;
-            return this;
-        }
-
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/SendInvoice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/SendInvoice.java
@@ -14,6 +14,7 @@ import lombok.ToString;
 import lombok.experimental.Tolerate;
 import org.apache.commons.lang3.StringUtils;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
+import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.payments.LabeledPrice;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
@@ -64,6 +65,7 @@ public class SendInvoice extends BotApiMethodMessage {
     private static final String MAXTIPAMOUNT_FIELD = "max_tip_amount";
     private static final String SUGGESTEDTIPAMOUNTS_FIELD = "suggested_tip_amounts";
     private static final String PROTECTCONTENT_FIELD = "protect_content";
+    private static final String REPLY_PARAMETERS_FIELD = "reply_parameters";
 
     @JsonProperty(CHATID_FIELD)
     @NonNull
@@ -167,6 +169,11 @@ public class SendInvoice extends BotApiMethodMessage {
     private List<Integer> suggestedTipAmounts;
     @JsonProperty(PROTECTCONTENT_FIELD)
     private Boolean protectContent; ///< Optional. Protects the contents of sent messages from forwarding and saving
+    /**
+     * Optional
+     * Description of the message to reply to
+     */
+    private ReplyParameters replyParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {
@@ -210,6 +217,9 @@ public class SendInvoice extends BotApiMethodMessage {
         }
         if (replyMarkup != null) {
             replyMarkup.validate();
+        }
+        if (replyParameters != null) {
+            replyParameters.validate();
         }
     }
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/name/GetMyName.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/name/GetMyName.java
@@ -27,7 +27,7 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 @AllArgsConstructor
 @Builder
 public class GetMyName extends BotApiMethod<BotName> {
-    public static final String PATH = "getMyDescription";
+    public static final String PATH = "getMyName";
 
     private static final String LANGUAGE_CODE_FIELD = "language_code";
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/DeleteStickerSet.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/DeleteStickerSet.java
@@ -1,0 +1,46 @@
+package org.telegram.telegrambots.meta.api.methods.stickers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodBoolean;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
+
+/**
+ * @author Ruben Bermudez
+ * @version 6.6
+ * Use this method to delete a sticker set that was created by the bot.
+ *
+ * Returns True on success.
+ *
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@Builder
+public class DeleteStickerSet extends BotApiMethodBoolean {
+    public static final String PATH = "deleteStickerSet";
+
+    public static final String NAME_FIELD = "name";
+
+    /**
+     * Sticker set name
+     */
+    @JsonProperty(NAME_FIELD)
+    @NonNull
+    private String name;
+
+    @Override
+    public String getMethod() {
+        return PATH;
+    }
+
+    @Override
+    public void validate() throws TelegramApiValidationException {
+        if (name.isEmpty() || name.length() > 64) {
+            throw new TelegramApiValidationException("name must be between 1 and 64 characters", this);
+        }
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerEmojiList.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerEmojiList.java
@@ -1,0 +1,61 @@
+package org.telegram.telegrambots.meta.api.methods.stickers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodBoolean;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
+
+import java.util.List;
+
+/**
+ * @author Ruben Bermudez
+ * @version 6.6
+ * Use this method to change the list of emoji assigned to a regular or custom emoji sticker.
+ * The sticker must belong to a sticker set created by the bot.
+ *
+ * Returns True on success.
+ *
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@Builder
+public class SetStickerEmojiList extends BotApiMethodBoolean {
+    public static final String PATH = "setStickerEmojiList";
+
+    public static final String STICKER_FIELD = "sticker";
+    public static final String EMOJI_LIST_FIELD = "emoji_list";
+
+    /**
+     * File identifier of the sticker
+     */
+    @JsonProperty(STICKER_FIELD)
+    @NonNull
+    private String sticker;
+
+    /**
+     * List of 1-20 emoji associated with the sticker
+     */
+    @JsonProperty(EMOJI_LIST_FIELD)
+    @NonNull
+    @Singular("emoji")
+    private List<String> emojiList;
+
+    @Override
+    public String getMethod() {
+        return PATH;
+    }
+
+    @Override
+    public void validate() throws TelegramApiValidationException {
+        if (sticker.isEmpty()) {
+            throw new TelegramApiValidationException("sticker can't be null", this);
+        }
+        if (emojiList.isEmpty() || emojiList.size() > 20) {
+            throw new TelegramApiValidationException("Emoji list must have between 1 and 20 items", this);
+        }
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerKeywords.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerKeywords.java
@@ -1,0 +1,63 @@
+package org.telegram.telegrambots.meta.api.methods.stickers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodBoolean;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
+
+import java.util.List;
+
+/**
+ * @author Ruben Bermudez
+ * @version 6.6
+ * Use this method to change search keywords assigned to a regular or custom emoji sticker.
+ * The sticker must belong to a sticker set created by the bot.
+ *
+ * Returns True on success.
+ *
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SetStickerKeywords extends BotApiMethodBoolean {
+    public static final String PATH = "setStickerKeywords";
+
+    public static final String STICKER_FIELD = "sticker";
+    public static final String KEYWORDS_FIELD = "keywords";
+
+    /**
+     * File identifier of the sticker
+     */
+    @JsonProperty(STICKER_FIELD)
+    @NonNull
+    private String sticker;
+
+    /**
+     * Optional.
+     * List of 0-20 search keywords for the sticker with total length of up to 64 characters.
+     * For “regular” and “custom_emoji” stickers only.
+     */
+    @JsonProperty(KEYWORDS_FIELD)
+    @Singular
+    private List<String> keywords;
+
+    @Override
+    public String getMethod() {
+        return PATH;
+    }
+
+    @Override
+    public void validate() throws TelegramApiValidationException {
+        if (sticker.isEmpty()) {
+            throw new TelegramApiValidationException("sticker can't be null", this);
+        }
+        if (keywords != null && keywords.size() > 20) {
+            throw new TelegramApiValidationException("Keywords list must have between 0 and 20 items", this);
+        }
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerMaskPosition.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerMaskPosition.java
@@ -1,0 +1,61 @@
+package org.telegram.telegrambots.meta.api.methods.stickers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodBoolean;
+import org.telegram.telegrambots.meta.api.objects.stickers.MaskPosition;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
+
+/**
+ * @author Ruben Bermudez
+ * @version 6.6
+ * Use this method to change the mask position of a mask sticker.
+ * The sticker must belong to a sticker set that was created by the bot.
+ *
+ * Returns True on success.
+ *
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SetStickerMaskPosition extends BotApiMethodBoolean {
+    public static final String PATH = "setStickerMaskPosition";
+
+    public static final String STICKER_FIELD = "sticker";
+    public static final String MASK_POSITION_FIELD = "mask_position";
+
+    /**
+     * File identifier of the sticker
+     */
+    @JsonProperty(STICKER_FIELD)
+    @NonNull
+    private String sticker;
+
+    /**
+     * Optional.
+     * Position where the mask should be placed on faces. For “mask” stickers only.
+     * Omit the parameter to remove the mask position.
+     */
+    @JsonProperty(MASK_POSITION_FIELD)
+    private MaskPosition maskPosition;
+
+    @Override
+    public String getMethod() {
+        return PATH;
+    }
+
+    @Override
+    public void validate() throws TelegramApiValidationException {
+        if (sticker.isEmpty()) {
+            throw new TelegramApiValidationException("sticker can't be null", this);
+        }
+        if (maskPosition != null) {
+            maskPosition.validate();
+        }
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerSetThumbnail.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerSetThumbnail.java
@@ -1,25 +1,16 @@
 package org.telegram.telegrambots.meta.api.methods.stickers;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodBoolean;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 
 /**
  * @author Ruben Bermudez
- * @version 1.0
+ * @version 6.6
  * Use this method to set the thumbnail of a regular or mask sticker set.
  * The format of the thumbnail file must match the format of the stickers in the set.
  * Returns True on success.
- * @deprecated Use {@link SetStickerSetThumbnail}
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
@@ -29,13 +20,12 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 @RequiredArgsConstructor
 @AllArgsConstructor
 @Builder
-@Deprecated
-public class SetStickerSetThumb extends BotApiMethodBoolean {
-    public static final String PATH = "setStickerSetThumb";
+public class SetStickerSetThumbnail extends BotApiMethodBoolean {
+    public static final String PATH = "setStickerSetThumbnail";
 
     public static final String NAME_FIELD = "name";
     public static final String USERID_FIELD = "user_id";
-    public static final String THUMB_FIELD = "thumb";
+    public static final String THUMBNAIL_FIELD = "thumbnail";
 
     /**
      * Sticker set name
@@ -61,7 +51,7 @@ public class SetStickerSetThumb extends BotApiMethodBoolean {
      *
      * If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail.
      */
-    private InputFile thumb;
+    private InputFile thumbnail;
 
     @Override
     public String getMethod() {
@@ -76,8 +66,8 @@ public class SetStickerSetThumb extends BotApiMethodBoolean {
         if (userId <= 0) {
             throw new TelegramApiValidationException("userId can't be null", this);
         }
-        if (thumb != null) {
-            thumb.validate();
+        if (thumbnail != null) {
+            thumbnail.validate();
         }
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerSetTitle.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/stickers/SetStickerSetTitle.java
@@ -1,0 +1,57 @@
+package org.telegram.telegrambots.meta.api.methods.stickers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodBoolean;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
+
+/**
+ * @author Ruben Bermudez
+ * @version 6.6
+ * Use this method to set the title of a created sticker set.
+ *
+ * Returns True on success.
+ *
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@Builder
+public class SetStickerSetTitle extends BotApiMethodBoolean {
+    public static final String PATH = "setStickerSetTitle";
+
+    public static final String NAME_FIELD = "name";
+    public static final String TITLE_FIELD = "title";
+
+    /**
+     * Sticker set name
+     */
+    @JsonProperty(NAME_FIELD)
+    @NonNull
+    private String name;
+
+    /**
+     * Sticker set title, 1-64 characters
+     */
+    @JsonProperty(TITLE_FIELD)
+    @NonNull
+    private String title;
+
+    @Override
+    public String getMethod() {
+        return PATH;
+    }
+
+    @Override
+    public void validate() throws TelegramApiValidationException {
+        if (name.isEmpty() || name.length() > 64) {
+            throw new TelegramApiValidationException("name must be between 1 and 64 characters", this);
+        }
+        if (title.isEmpty() || title.length() > 64) {
+            throw new TelegramApiValidationException("title must be between 1 and 64 characters", this);
+        }
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/AllowedUpdates.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/AllowedUpdates.java
@@ -12,4 +12,11 @@ public final class AllowedUpdates {
     public static final String INLINEQUERY = "inline_query";
     public static final String CHOSENINLINERESULT = "chosen_inline_result";
     public static final String CALLBACKQUERY = "callback_query";
+    public static final String SHIPPINGQUERY = "shipping_query";
+    public static final String PRECHECKOUTQUERY = "pre_checkout_query";
+    public static final String POLL = "poll";
+    public static final String POLLANSWER = "poll_answer";
+    public static final String MYCHATMEMBER = "my_chat_member";
+    public static final String CHATMEMBER = "chat_member";
+    public static final String CHATJOINREQUEST = "chat_join_request";
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Chat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Chat.java
@@ -303,7 +303,7 @@ public class Chat implements BotApiObject {
      * Returned only in getChat.
      */
     @JsonProperty(PROFILE_BACKGROUND_CUSTOM_EMOJI_ID_FIELD)
-    private Boolean profileBackgroundCustomEmojiId;
+    private String profileBackgroundCustomEmojiId;
     /**
      * Optional.
      * True, if new chat members will have access to old messages; available only to chat administrators.

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Chat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Chat.java
@@ -16,7 +16,7 @@ import org.telegram.telegrambots.meta.api.objects.reactions.ReactionType;
 import java.util.List;
 
 /**
- * This object represents a Telegram chat with an user or a group
+ * This object represents a Telegram chat with a user or a group
  * @author Ruben Bermudez
  * @version 6.1
  */
@@ -65,6 +65,8 @@ public class Chat implements BotApiObject {
     private static final String HAS_VISIBLE_HISTORY_FIELD  = "has_visible_history";
     private static final String EMOJI_STATUS_CUSTOM_ID_FIELD  = "emoji_status_custom_emoji_id";
     private static final String EMOJI_STATUS_EXPIRATION_DATE_FIELD  = "emoji_status_expiration_date";
+    private static final String UNRESTRICT_BOOST_COUNT_FIELD  = "unrestrict_boost_count";
+    private static final String CUSTOM_EMOJI_STICKER_SET_NAME_FIELD  = "custom_emoji_sticker_set_name";
 
 
     private static final String USERCHATTYPE = "private";
@@ -311,6 +313,22 @@ public class Chat implements BotApiObject {
      */
     @JsonProperty(HAS_VISIBLE_HISTORY_FIELD)
     private Boolean hasVisibleHistory;
+    /**
+     * Optional.
+     * For supergroups, the minimum number of boosts that a non-administrator
+     * user needs to add in order to ignore slow mode and chat permissions.
+     * Returned only in getChat.
+     */
+    @JsonProperty(UNRESTRICT_BOOST_COUNT_FIELD)
+    private Integer unrestrictBoostCount;
+    /**
+     * Optional.
+     * For supergroups, the name of the group's custom emoji sticker set. Custom emoji from
+     * this set can be used by all users and bots in the group.
+     * Returned only in getChat.
+     */
+    @JsonProperty(CUSTOM_EMOJI_STICKER_SET_NAME_FIELD)
+    private Boolean customEmojiStickerSetName;
 
     @JsonIgnore
     public Boolean isGroupChat() {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/InaccessibleMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/InaccessibleMessage.java
@@ -41,7 +41,7 @@ public class InaccessibleMessage implements MaybeInaccessibleMessage {
      * The field can be used to differentiate regular and inaccessible messages.
      */
     @JsonProperty(DATE_FIELD)
-    private Integer DATE;
+    private Integer date;
 
     @Override
     public Long getChatId() {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/MaybeInaccessibleMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/MaybeInaccessibleMessage.java
@@ -22,4 +22,6 @@ public interface MaybeInaccessibleMessage extends BotApiObject {
     }
 
     Long getChatId();
+
+    Integer getMessageId();
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/MaybeInaccessibleMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/MaybeInaccessibleMessage.java
@@ -24,4 +24,6 @@ public interface MaybeInaccessibleMessage extends BotApiObject {
     Long getChatId();
 
     Integer getMessageId();
+
+    Integer getDate();
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Message.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Message.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostAdded;
 import org.telegram.telegrambots.meta.api.objects.forum.ForumTopicClosed;
 import org.telegram.telegrambots.meta.api.objects.forum.ForumTopicCreated;
 import org.telegram.telegrambots.meta.api.objects.forum.ForumTopicEdited;
@@ -133,6 +134,9 @@ public class Message implements MaybeInaccessibleMessage {
     private static final String GIVEAWAY_FIELD = "giveaway";
     private static final String GIVEAWAY_WINNERS_FIELD = "giveaway_winners";
     private static final String GIVEAWAY_COMPLETED_FIELD = "giveaway_completed";
+    private static final String REPLY_TO_STORY_FIELD = "reply_to_story";
+    private static final String BOOST_ADDED_FIELD = "boost_added";
+    private static final String SENDER_BOOST_COUNT_FIELD = "sender_boost_count";
 
     /**
      * Integer	Unique message identifier
@@ -640,6 +644,24 @@ public class Message implements MaybeInaccessibleMessage {
      */
     @JsonProperty(GIVEAWAY_COMPLETED_FIELD)
     private GiveawayCompleted giveawayCompleted;
+    /**
+     * Optional.
+     * For replies to a story, the original message
+     */
+    @JsonProperty(REPLY_TO_STORY_FIELD)
+    private Story replyToStory;
+    /**
+     * Optional.
+     * The message is a service message about a user boosting the chat
+     */
+    @JsonProperty(BOOST_ADDED_FIELD)
+    private ChatBoostAdded boostAdded;
+    /**
+     * Optional.
+     * If the sender of the message boosted the chat, the number of boosts added by the user
+     */
+    @JsonProperty(SENDER_BOOST_COUNT_FIELD)
+    private Integer senderBoostCount;
 
 
     public List<MessageEntity> getEntities() {
@@ -876,5 +898,15 @@ public class Message implements MaybeInaccessibleMessage {
     @JsonIgnore
     private boolean hasWriteAccessAllowed() {
         return writeAccessAllowed != null;
+    }
+
+    @JsonIgnore
+    private boolean hasReplyToStory() {
+        return replyToStory != null;
+    }
+
+    @JsonIgnore
+    private boolean hasBoostAdded() {
+        return boostAdded != null;
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/WriteAccessAllowed.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/WriteAccessAllowed.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
@@ -19,6 +20,7 @@ import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 @Getter
 @Setter
 @ToString
+@NoArgsConstructor
 @AllArgsConstructor
 public class WriteAccessAllowed implements BotApiObject {
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/WriteAccessAllowed.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/WriteAccessAllowed.java
@@ -20,7 +20,7 @@ import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 @Getter
 @Setter
 @ToString
-@NoArgsConstructor
+@NoArgsConstructor(force = true)
 @AllArgsConstructor
 public class WriteAccessAllowed implements BotApiObject {
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/adminrights/ChatAdministratorRights.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/adminrights/ChatAdministratorRights.java
@@ -20,7 +20,7 @@ import org.telegram.telegrambots.meta.api.interfaces.Validable;
 public class ChatAdministratorRights implements BotApiObject, Validable {
 
     private static final String ISANONYMOUS_FIELD = "is_anonymous";
-    private static final String CANMANAGECHAT_FIELD = "can_manage_chat";
+    private static final String CAN_MANAGE_CHAT_FIELD = "can_manage_chat";
     private static final String CANDELETEMESSAGES_FIELD = "can_delete_messages";
     private static final String CANMANAGEVIDEOCHATS_FIELD = "can_manage_video_chats";
     private static final String CANRESTRICTMEMBERS_FIELD = "can_restrict_members";
@@ -42,11 +42,11 @@ public class ChatAdministratorRights implements BotApiObject, Validable {
     @NonNull
     private Boolean isAnonymous;
     /**
-     * True, if the administrator can access the chat event log, chat statistics, boost list in channels,
-     * message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode.
-     * Implied by any other administrator privilege
+     * True, if the administrator can access the chat event log, get boost list,
+     * see hidden supergroup and channel members, report spam messages and ignore slow mode.
+     * Implied by any other administrator privilege.
      */
-    @JsonProperty(CANMANAGECHAT_FIELD)
+    @JsonProperty(CAN_MANAGE_CHAT_FIELD)
     @NonNull
     private Boolean canManageChat;
     /**
@@ -113,13 +113,13 @@ public class ChatAdministratorRights implements BotApiObject, Validable {
     private Boolean canManageTopics;
     /**
      * Optional.
-     * True, if the administrator can post stories in the channel; channels only
+     * True, if the administrator can post stories to the chat
      */
     @JsonProperty(CAN_POST_STORIES_FIELD)
     private Boolean canPostStories;
     /**
      * Optional.
-     * True, if the administrator can edit stories posted by other users; channels only
+     * True, if the administrator can edit stories posted by other users
      */
     @JsonProperty(CAN_EDIT_STORIES_FIELD)
     private Boolean canEditStories;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/boost/ChatBoostAdded.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/boost/ChatBoostAdded.java
@@ -1,0 +1,35 @@
+package org.telegram.telegrambots.meta.api.objects.boost;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+
+/**
+ * @author Ruben Bermudez
+ * @version 7.1
+ * This object represents a service message about a user boosting a chat.
+ */
+@JsonDeserialize
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+@Builder
+public class ChatBoostAdded implements BotApiObject {
+    private static final String BOOST_COUNT_FIELD = "boost_count";
+
+    /**
+     * Number of boosts added by the user
+     */
+    @JsonProperty(BOOST_COUNT_FIELD)
+    private Integer boostCount;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberAdministrator.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberAdministrator.java
@@ -33,7 +33,7 @@ public class ChatMemberAdministrator implements ChatMember {
     private static final String CANBEEDITED_FIELD = "can_be_edited";
     private static final String CUSTOMTITLE_FIELD = "custom_title";
     private static final String ISANONYMOUS_FIELD = "is_anonymous";
-    private static final String CANMANAGECHAT_FIELD = "can_manage_chat";
+    private static final String CAN_MANAGE_CHAT_FIELD = "can_manage_chat";
     private static final String CANPOSTMESSAGES_FIELD = "can_post_messages";
     private static final String CANEDITMESSAGES_FIELD = "can_edit_messages";
     private static final String CANDELETEMESSAGES_FIELD = "can_delete_messages";
@@ -74,11 +74,12 @@ public class ChatMemberAdministrator implements ChatMember {
     @JsonProperty(ISANONYMOUS_FIELD)
     private Boolean isAnonymous;
     /**
-     * True, if the administrator can access the chat event log, chat statistics, boost list in channels,
-     * message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode.
-     * Implied by any other administrator privilege
+     * True, if the administrator can access the chat event log, get boost list,
+     * see hidden supergroup and channel members, report spam messages and ignore slow mode.
+     *
+     * Implied by any other administrator privilege.
      */
-    @JsonProperty(CANMANAGECHAT_FIELD)
+    @JsonProperty(CAN_MANAGE_CHAT_FIELD)
     private Boolean canManageChat;
     /**
      * True, if the administrator can post messages in the channel; channels only
@@ -135,13 +136,13 @@ public class ChatMemberAdministrator implements ChatMember {
     private Boolean canManageTopics;
     /**
      * Optional.
-     * True, if the administrator can post stories in the channel; channels only
+     * True, if the administrator can post stories to the chat
      */
     @JsonProperty(CAN_POST_STORIES_FIELD)
     private Boolean canPostStories;
     /**
      * Optional.
-     * True, if the administrator can edit stories posted by other users; channels only
+     * True, if the administrator can edit stories posted by other users
      */
     @JsonProperty(CAN_EDIT_STORIES_FIELD)
     private Boolean canEditStories;

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/reactions/ReactionTypeCustomEmoji.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/reactions/ReactionTypeCustomEmoji.java
@@ -48,7 +48,7 @@ public class ReactionTypeCustomEmoji implements ReactionType {
         if (customEmoji.isEmpty()) {
             throw new TelegramApiValidationException("CustomEmoji parameter can't be empty", this);
         }
-        if (ReactionType.CUSTOM_EMOJI_TYPE.equals(type)) {
+        if (!ReactionType.CUSTOM_EMOJI_TYPE.equals(type)) {
             throw new TelegramApiValidationException("Type must be \"custom_emoji\"", this);
         }
     }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/reactions/ReactionTypeEmoji.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/reactions/ReactionTypeEmoji.java
@@ -52,7 +52,7 @@ public class ReactionTypeEmoji implements ReactionType {
         if (emoji.isEmpty()) {
             throw new TelegramApiValidationException("Emoji parameter can't be empty", this);
         }
-        if (ReactionType.EMOJI_TYPE.equals(type)) {
+        if (!ReactionType.EMOJI_TYPE.equals(type)) {
             throw new TelegramApiValidationException("Type must be \"emoji\"", this);
         }
     }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/replykeyboard/ForceReplyKeyboard.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/replykeyboard/ForceReplyKeyboard.java
@@ -64,7 +64,7 @@ public class ForceReplyKeyboard implements ReplyKeyboard {
         if (forceReply == null) {
             throw new TelegramApiValidationException("ForceReply parameter can't not be null", this);
         }
-        if (inputFieldPlaceholder != null && (inputFieldPlaceholder.length() < 1 || inputFieldPlaceholder.length() > 64)) {
+        if (inputFieldPlaceholder != null && (inputFieldPlaceholder.isEmpty() || inputFieldPlaceholder.length() > 64)) {
             throw new TelegramApiValidationException("InputFieldPlaceholder must be between 1 and 64 characters", this);
         }
     }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/replykeyboard/ReplyKeyboardMarkup.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/replykeyboard/ReplyKeyboardMarkup.java
@@ -75,7 +75,7 @@ public class ReplyKeyboardMarkup implements ReplyKeyboard {
         if (keyboard == null) {
             throw new TelegramApiValidationException("Keyboard parameter can't be null", this);
         }
-        if (inputFieldPlaceholder != null && (inputFieldPlaceholder.length() < 1 || inputFieldPlaceholder.length() > 64)) {
+        if (inputFieldPlaceholder != null && (inputFieldPlaceholder.isEmpty() || inputFieldPlaceholder.length() > 64)) {
             throw new TelegramApiValidationException("InputFieldPlaceholder must be between 1 and 64 characters", this);
         }
         for (KeyboardRow keyboardButtons : keyboard) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/stickers/InputSticker.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/stickers/InputSticker.java
@@ -1,14 +1,7 @@
 package org.telegram.telegrambots.meta.api.objects.stickers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.Singular;
-import lombok.ToString;
+import lombok.*;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 import org.telegram.telegrambots.meta.api.interfaces.Validable;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
@@ -28,6 +21,7 @@ import java.util.List;
 @ToString
 @NoArgsConstructor(force = true)
 @AllArgsConstructor
+@Builder
 public class InputSticker implements BotApiObject, Validable {
 
     private static final String STICKER_FIELD = "sticker";
@@ -49,7 +43,8 @@ public class InputSticker implements BotApiObject, Validable {
      * List of 1-20 emoji associated with the sticker
      */
     @JsonProperty(EMOJI_LIST_FIELD)
-    @Singular
+    @NonNull
+    @Singular("emoji")
     private List<String> emojiList;
 
     /**
@@ -73,10 +68,9 @@ public class InputSticker implements BotApiObject, Validable {
             throw new TelegramApiValidationException("Emoji list must have between 1 and 20 items", this);
         }
 
-        if (keywords.size() > 20) {
+        if (keywords != null && keywords.size() > 20) {
             throw new TelegramApiValidationException("Keywords list must have between 0 and 20 items", this);
         }
-
 
         if (maskPosition != null) {
             maskPosition.validate();

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/stories/Story.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/stories/Story.java
@@ -1,18 +1,39 @@
 package org.telegram.telegrambots.meta.api.objects.stories;
 
-import lombok.Builder;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.Chat;
 
+/**
+ * @author Ruben Bermudez
+ * @version 7.1
+ *
+ * This object represents a story.
+ */
 @EqualsAndHashCode(callSuper = false)
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
-@Builder
+@AllArgsConstructor
 public class Story implements BotApiObject {
+    private static final String CHAT_FIELD = "chat";
+    private static final String ID_FIELD = "id";
+
+    /**
+     * Chat that posted the story
+     */
+    @JsonProperty(CHAT_FIELD)
+    private Chat chat;
+    /**
+     * Unique identifier for the story in the chat
+     */
+    @JsonProperty(ID_FIELD)
+    private Integer id;
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/bots/AbsSender.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/bots/AbsSender.java
@@ -12,10 +12,7 @@ import org.telegram.telegrambots.meta.api.methods.send.SendSticker;
 import org.telegram.telegrambots.meta.api.methods.send.SendVideo;
 import org.telegram.telegrambots.meta.api.methods.send.SendVideoNote;
 import org.telegram.telegrambots.meta.api.methods.send.SendVoice;
-import org.telegram.telegrambots.meta.api.methods.stickers.AddStickerToSet;
-import org.telegram.telegrambots.meta.api.methods.stickers.CreateNewStickerSet;
-import org.telegram.telegrambots.meta.api.methods.stickers.SetStickerSetThumb;
-import org.telegram.telegrambots.meta.api.methods.stickers.UploadStickerFile;
+import org.telegram.telegrambots.meta.api.methods.stickers.*;
 import org.telegram.telegrambots.meta.api.methods.updates.GetWebhookInfo;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageMedia;
 import org.telegram.telegrambots.meta.api.objects.File;
@@ -157,8 +154,18 @@ public abstract class AbsSender {
      * @param setStickerSetThumb Information of the sticker to set
      * @return If success, true is returned
      * @throws TelegramApiException If there is any error setting the thumb to the set
+     * @deprecated Use {{@link #execute(SetStickerSetThumbnail)}}
      */
+    @Deprecated
     public abstract Boolean execute(SetStickerSetThumb setStickerSetThumb) throws TelegramApiException;
+
+    /**
+     * Set sticker set thumbnail (https://core.telegram.org/bots/api#setstickersetthumbnail)
+     * @param setStickerSetThumbnail Information of the sticker's thumbnail to set
+     * @return If success, true is returned
+     * @throws TelegramApiException If there is any error setting the thumbnail to the set
+     */
+    public abstract Boolean execute(SetStickerSetThumbnail setStickerSetThumbnail) throws TelegramApiException;
 
     /**
      * Creates a new sticker set (https://core.telegram.org/bots/api#createNewStickerSet)
@@ -244,8 +251,17 @@ public abstract class AbsSender {
      * Set sticker set thumb (https://core.telegram.org/bots/api#setStickerSetThumb)
      * @param setStickerSetThumb Information of the sticker to set
      * @return If success, true is returned
+     * @deprecated Use {@link #executeAsync(SetStickerSetThumbnail)}
      */
+    @Deprecated
     public abstract CompletableFuture<Boolean> executeAsync(SetStickerSetThumb setStickerSetThumb);
+
+    /**
+     * Set sticker set thumb (https://core.telegram.org/bots/api#setstickersetthumbnail)
+     * @param setStickerSetThumbnail Information of the sticker's thumbnail to set
+     * @return If success, true is returned
+     */
+    public abstract CompletableFuture<Boolean> executeAsync(SetStickerSetThumbnail setStickerSetThumbnail);
 
     /**
      * Creates a new sticker set (https://core.telegram.org/bots/api#createNewStickerSet)

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/exceptions/TelegramApiValidationException.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/exceptions/TelegramApiValidationException.java
@@ -26,10 +26,10 @@ import org.telegram.telegrambots.meta.api.methods.PartialBotApiMethod;
  * Exception from method validations
  */
 public class TelegramApiValidationException extends TelegramApiException {
-    private PartialBotApiMethod method;
+    private PartialBotApiMethod<?> method;
     private BotApiObject object;
 
-    public TelegramApiValidationException(String message, PartialBotApiMethod method) {
+    public TelegramApiValidationException(String message, PartialBotApiMethod<?> method) {
         super(message);
         this.method = method;
     }
@@ -43,7 +43,7 @@ public class TelegramApiValidationException extends TelegramApiException {
         return object;
     }
 
-    public PartialBotApiMethod getMethod() {
+    public PartialBotApiMethod<?> getMethod() {
         return method;
     }
 

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethodTest.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethodTest.java
@@ -1,0 +1,43 @@
+package org.telegram.telegrambots.meta.api.methods;
+
+
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * @author Roman Bondar
+ */
+
+public class PartialBotApiMethodTest {
+
+    @Test
+    public void deserializeUpdateWithWriteAccessAllowedNotThrowApiException() throws IOException {
+
+        String answer = new String(Files.readAllBytes(Paths.get("src/test/resources/fixtures/update-with-write-access-allowed-for-webapp.json")));
+
+        PartialBotApiMethod method = new PartialBotApiMethod() {
+            @Override
+            public Serializable deserializeResponse(String answer) throws TelegramApiRequestException {
+                return deserializeResponseArray(answer, Update.class);
+            }
+
+            @Override
+            public String getMethod() {
+                return "method";
+            }
+        };
+
+        String finalAnswer = answer;
+        assertDoesNotThrow(() -> method.deserializeResponse(finalAnswer),
+                "deserializeResponse should not throw if write access allowed passed into it ");
+
+    }
+}

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethodTest.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethodTest.java
@@ -23,7 +23,7 @@ public class PartialBotApiMethodTest {
 
         String answer = new String(Files.readAllBytes(Paths.get("src/test/resources/fixtures/update-with-write-access-allowed-for-webapp.json")));
 
-        PartialBotApiMethod method = new PartialBotApiMethod() {
+        PartialBotApiMethod<Serializable> method = new PartialBotApiMethod<Serializable>() {
             @Override
             public Serializable deserializeResponse(String answer) throws TelegramApiRequestException {
                 return deserializeResponseArray(answer, Update.class);

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethodTest.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/PartialBotApiMethodTest.java
@@ -35,9 +35,7 @@ public class PartialBotApiMethodTest {
             }
         };
 
-        String finalAnswer = answer;
-        assertDoesNotThrow(() -> method.deserializeResponse(finalAnswer),
-                "deserializeResponse should not throw if write access allowed passed into it ");
+        assertDoesNotThrow(() -> method.deserializeResponse(answer), "deserializeResponse should not throw if write access allowed passed into it ");
 
     }
 }

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/menubutton/GetChatMenuButtonTest.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/menubutton/GetChatMenuButtonTest.java
@@ -5,11 +5,7 @@ import org.telegram.telegrambots.meta.api.objects.menubutton.MenuButton;
 import org.telegram.telegrambots.meta.api.objects.menubutton.MenuButtonDefault;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Ruben Bermudez
@@ -48,7 +44,7 @@ public class GetChatMenuButtonTest {
         try {
             MenuButton result = getChatMenuButton.deserializeResponse(responseText);
             assertNotNull(result);
-            assertTrue(result instanceof MenuButtonDefault);
+            assertInstanceOf(MenuButtonDefault.class, result);
         } catch (TelegramApiRequestException e) {
             fail(e.getMessage());
         }

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/TestDeserialization.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/TestDeserialization.java
@@ -325,7 +325,7 @@ class TestDeserialization {
         ChatMember chatMember = new GetChatMember().deserializeResponse(updateText);
 
         assertNotNull(chatMember);
-        assertTrue(chatMember instanceof ChatMemberRestricted);
+        assertInstanceOf(ChatMemberRestricted.class, chatMember);
         ChatMemberRestricted chatMemberRestricted = (ChatMemberRestricted) chatMember;
         assertNotNull(chatMemberRestricted.getUser());
         assertEquals(1111111, chatMemberRestricted.getUser().getId());

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/TestTelegramApi.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/TestTelegramApi.java
@@ -51,7 +51,7 @@ class TestTelegramApi {
             TelegramBotsApi telegramBotsApi = new TelegramBotsApi(BotSession.class, null);
             telegramBotsApi.registerBot(new WebhookBot() {
                 @Override
-                public BotApiMethod onWebhookUpdateReceived(Update update) {
+                public BotApiMethod<?> onWebhookUpdateReceived(Update update) {
                     return null;
                 }
 

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/apimethods/TestSetGameScore.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/test/apimethods/TestSetGameScore.java
@@ -9,9 +9,7 @@ import org.telegram.telegrambots.meta.test.TelegramBotsHelper;
 
 import java.io.Serializable;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Ruben Bermudez
@@ -44,7 +42,7 @@ class TestSetGameScore {
         Serializable result =
                 setGameScore.deserializeResponse(TelegramBotsHelper.GetSetGameScoreBooleanResponse());
         assertNotNull(result);
-        assertTrue(result instanceof Boolean);
+        assertInstanceOf(Boolean.class, result);
         assertTrue((Boolean) result);
     }
 
@@ -52,6 +50,6 @@ class TestSetGameScore {
     void TestGetUpdatesMustDeserializeCorrectMessageResponse() throws Exception {
         Serializable result = setGameScore.deserializeResponse(TelegramBotsHelper.GetSetGameScoreMessageResponse());
         assertNotNull(result);
-        assertTrue(result instanceof Message);
+        assertInstanceOf(Message.class, result);
     }
 }

--- a/telegrambots-meta/src/test/resources/fixtures/update-with-write-access-allowed-for-webapp.json
+++ b/telegrambots-meta/src/test/resources/fixtures/update-with-write-access-allowed-for-webapp.json
@@ -1,0 +1,28 @@
+{
+  "ok": true,
+  "result": [
+    {
+      "update_id": 329421221,
+      "message": {
+        "message_id": 180,
+        "from": {
+          "id": 11111111,
+          "is_bot": false,
+          "first_name": "Alice Bob",
+          "username": "alicebob",
+          "language_code": "ru"
+        },
+        "chat": {
+          "id": 11111111,
+          "first_name": "Alice Bob",
+          "username": "alicebob",
+          "type": "private"
+        },
+        "date": 1707944280,
+        "write_access_allowed": {
+          "web_app_name": "alicebobshop"
+        }
+      }
+    }
+  ]
+}

--- a/telegrambots-spring-boot-starter/README.md
+++ b/telegrambots-spring-boot-starter/README.md
@@ -18,14 +18,14 @@ Usage
     <dependency>
         <groupId>org.telegram</groupId>
         <artifactId>telegrambots-spring-boot-starter</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </dependency>
 ```
 
 **Gradle**
 
 ```gradle
-    implementation 'org.telegram:telegrambots-spring-boot-starter:6.9.7.0'
+    implementation 'org.telegram:telegrambots-spring-boot-starter:6.9.7.1'
 ```
 
 Motivation

--- a/telegrambots-spring-boot-starter/pom.xml
+++ b/telegrambots-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </parent>
 
     <artifactId>telegrambots-spring-boot-starter</artifactId>
@@ -70,7 +70,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <telegrambots.version>6.9.7.0</telegrambots.version>
+        <telegrambots.version>6.9.7.1</telegrambots.version>
         <spring-boot.version>2.7.18</spring-boot.version>
 
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>

--- a/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/SpringWebhookBot.java
+++ b/telegrambots-spring-boot-starter/src/main/java/org/telegram/telegrambots/starter/SpringWebhookBot.java
@@ -63,7 +63,7 @@ public abstract class SpringWebhookBot extends TelegramWebhookBot {
         }
 
         @Override
-        public BotApiMethod onWebhookUpdateReceived(Update update) {
+        public BotApiMethod<?> onWebhookUpdateReceived(Update update) {
             return null;
         }
 

--- a/telegrambots/pom.xml
+++ b/telegrambots/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>6.9.7.0</version>
+        <version>6.9.7.1</version>
     </parent>
 
     <artifactId>telegrambots</artifactId>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots-meta</artifactId>
-            <version>6.9.7.0</version>
+            <version>6.9.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/bots/DefaultAbsSender.java
@@ -25,10 +25,7 @@ import org.telegram.telegrambots.meta.api.methods.send.SendSticker;
 import org.telegram.telegrambots.meta.api.methods.send.SendVideo;
 import org.telegram.telegrambots.meta.api.methods.send.SendVideoNote;
 import org.telegram.telegrambots.meta.api.methods.send.SendVoice;
-import org.telegram.telegrambots.meta.api.methods.stickers.AddStickerToSet;
-import org.telegram.telegrambots.meta.api.methods.stickers.CreateNewStickerSet;
-import org.telegram.telegrambots.meta.api.methods.stickers.SetStickerSetThumb;
-import org.telegram.telegrambots.meta.api.methods.stickers.UploadStickerFile;
+import org.telegram.telegrambots.meta.api.methods.stickers.*;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageMedia;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
@@ -666,6 +663,7 @@ public abstract class DefaultAbsSender extends AbsSender {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Boolean execute(AddStickerToSet addStickerToSet) throws TelegramApiException {
         assertParamNotNull(addStickerToSet, "addStickerToSet");
@@ -705,6 +703,10 @@ public abstract class DefaultAbsSender extends AbsSender {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
     @Override
     public Boolean execute(SetStickerSetThumb setStickerSetThumb) throws TelegramApiException {
         assertParamNotNull(setStickerSetThumb, "setStickerSetThumb");
@@ -729,6 +731,31 @@ public abstract class DefaultAbsSender extends AbsSender {
         }
     }
 
+    @Override
+    public Boolean execute(SetStickerSetThumbnail setStickerSetThumbnail) throws TelegramApiException {
+        assertParamNotNull(setStickerSetThumbnail, "setStickerSetThumbnail");
+        setStickerSetThumbnail.validate();
+        try {
+            String url = getBaseUrl() + SetStickerSetThumbnail.PATH;
+            HttpPost httppost = configuredHttpPost(url);
+            MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+            builder.setLaxMode();
+            builder.setCharset(StandardCharsets.UTF_8);
+            builder.addTextBody(SetStickerSetThumbnail.USERID_FIELD, setStickerSetThumbnail.getUserId().toString(), TEXT_PLAIN_CONTENT_TYPE);
+            builder.addTextBody(SetStickerSetThumbnail.NAME_FIELD, setStickerSetThumbnail.getName(), TEXT_PLAIN_CONTENT_TYPE);
+            if (setStickerSetThumbnail.getThumbnail() != null) {
+                addInputFile(builder, setStickerSetThumbnail.getThumbnail(), SetStickerSetThumbnail.THUMBNAIL_FIELD, true);
+            }
+            HttpEntity multipart = builder.build();
+            httppost.setEntity(multipart);
+
+            return setStickerSetThumbnail.deserializeResponse(sendHttpPostRequest(httppost));
+        } catch (IOException e) {
+            throw new TelegramApiException("Unable to set sticker set thumbnail", e);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
     @Override
     public Boolean execute(CreateNewStickerSet createNewStickerSet) throws TelegramApiException {
         assertParamNotNull(createNewStickerSet, "createNewStickerSet");
@@ -1028,12 +1055,29 @@ public abstract class DefaultAbsSender extends AbsSender {
         return completableFuture;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
     @Override
     public CompletableFuture<Boolean> executeAsync(SetStickerSetThumb setStickerSetThumb) {
         CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
         exe.submit(() -> {
             try {
                 completableFuture.complete(execute(setStickerSetThumb));
+            } catch (TelegramApiException e) {
+                completableFuture.completeExceptionally(e);
+            }
+        });
+        return completableFuture;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> executeAsync(SetStickerSetThumbnail setStickerSetThumbnail) {
+        CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
+        exe.submit(() -> {
+            try {
+                completableFuture.complete(execute(setStickerSetThumbnail));
             } catch (TelegramApiException e) {
                 completableFuture.completeExceptionally(e);
             }

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/ServerlessWebhookTest.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/ServerlessWebhookTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.test.Fakes.FakeWebhook;
+import org.telegram.telegrambots.test.fakes.FakeWebhook;
 import org.telegram.telegrambots.updatesreceivers.ServerlessWebhook;
 
 import java.io.IOException;

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/TestDefaultBotSession.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/TestDefaultBotSession.java
@@ -16,7 +16,7 @@ import org.telegram.telegrambots.meta.TelegramBotsApi;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.generics.BackOff;
 import org.telegram.telegrambots.meta.generics.LongPollingBot;
-import org.telegram.telegrambots.test.Fakes.FakeLongPollingBot;
+import org.telegram.telegrambots.test.fakes.FakeLongPollingBot;
 import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
 import org.telegram.telegrambots.updatesreceivers.ExponentialBackOff;
 

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/TestRestApi.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/TestRestApi.java
@@ -43,7 +43,7 @@ import org.telegram.telegrambots.meta.api.objects.UserProfilePhotos;
 import org.telegram.telegrambots.meta.api.objects.WebhookInfo;
 import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
 import org.telegram.telegrambots.meta.api.objects.games.GameHighScore;
-import org.telegram.telegrambots.test.Fakes.FakeWebhook;
+import org.telegram.telegrambots.test.fakes.FakeWebhook;
 import org.telegram.telegrambots.updatesreceivers.DefaultExceptionMapper;
 import org.telegram.telegrambots.updatesreceivers.RestApi;
 

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/fakes/FakeLongPollingBot.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/fakes/FakeLongPollingBot.java
@@ -1,4 +1,4 @@
-package org.telegram.telegrambots.test.Fakes;
+package org.telegram.telegrambots.test.fakes;
 
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.bots.DefaultBotOptions;

--- a/telegrambots/src/test/java/org/telegram/telegrambots/test/fakes/FakeWebhook.java
+++ b/telegrambots/src/test/java/org/telegram/telegrambots/test/fakes/FakeWebhook.java
@@ -1,4 +1,4 @@
-package org.telegram.telegrambots.test.Fakes;
+package org.telegram.telegrambots.test.fakes;
 
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;


### PR DESCRIPTION
**Summary**
This pull request makes the following improvements:
- Refactor verbose code constructs
- Fix raw use of parameterized class
- Fix redundant type cast
- Add integrety check and small improvements in testing
- Refactor package name
- Delete unnecessary import
- Fix MD list items numbering

**Details**
- Added lambda expressions and utilized library methods to reduce code verbosity
- Such raw use of generic types is valid in Java, but it defeats the purpose of type parameters and may mask bugs
- Removed unnecessary cast expressions
- Added integrety check in SilentSenderTest.java, and replaced in all tests the assertTrue method with check on instanceof with the respective assertInstanceOf library method
- Refactored the org.telegram.telegrambots.test.Fakes package to match the convention. Package names are written in all lower case to avoid conflict with the names of classes or interfaces
- Removed import lombok.extern.jackson.Jacksonized from AnswerInlineQuery.java class as it is not used
- Small fixes on MD files for incorrect numbering in lists

**Benefits**
Improved code organization, maintainability, and readability.
Reduced redundancy and enhanced robustness of the code.