### PR TITLE
Fix Cxeb68d52e-5509: Upgrade HttpClient 4.5.14 to 5.3.1

### DIFF
--- a/telegrambots/pom.xml
+++ b/telegrambots/pom.xml
@@ -72,6 +72,7 @@
 
         <glassfish.version>2.41</glassfish.version>
         <httpcompontents.version>4.5.14</httpcompontents.version>
+        <httpcompontents5.version>5.3.1</httpcompontents5.version>
         <commonio.version>2.15.1</commonio.version>
     </properties>
 
@@ -153,9 +154,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpcompontents.version}</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${httpcompontents5.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
org.apache.httpcomponents:httpclient contains Vulnerability [Cxeb68d52e-5509](https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/)