### PR TITLE
Add optional 'isDebugMode' parameter to AbilityBot implementations

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/AbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/AbilityBot.java
@@ -16,16 +16,32 @@ import static org.telegram.telegrambots.abilitybots.api.db.MapDBContext.onlineIn
  * @author Abbas Abou Daya
  */
 public abstract class AbilityBot extends BaseAbilityBot {
+    protected AbilityBot(TelegramClient telegramClient, String botUsername, DBContext db, AbilityToggle toggle, boolean isDebugMode) {
+        super(telegramClient, botUsername, db, toggle, isDebugMode);
+    }
+
     protected AbilityBot(TelegramClient telegramClient, String botUsername, DBContext db, AbilityToggle toggle) {
-        super(telegramClient, botUsername, db, toggle);
+        super(telegramClient, botUsername, db, toggle, false);
+    }
+
+    protected AbilityBot(TelegramClient telegramClient, String botUsername, AbilityToggle toggle, boolean isDebugMode) {
+        this(telegramClient, botUsername, onlineInstance(botUsername), toggle, isDebugMode);
     }
 
     protected AbilityBot(TelegramClient telegramClient, String botUsername, AbilityToggle toggle) {
         this(telegramClient, botUsername, onlineInstance(botUsername), toggle);
     }
 
+    protected AbilityBot(TelegramClient telegramClient, String botUsername, DBContext db, boolean isDebugMode) {
+        this(telegramClient, botUsername, db, new DefaultToggle(), isDebugMode);
+    }
+
     protected AbilityBot(TelegramClient telegramClient, String botUsername, DBContext db) {
         this(telegramClient, botUsername, db, new DefaultToggle());
+    }
+
+    protected AbilityBot(TelegramClient telegramClient, String botUsername, boolean isDebugMode) {
+        this(telegramClient, botUsername, onlineInstance(botUsername), isDebugMode);
     }
 
     protected AbilityBot(TelegramClient telegramClient, String botUsername) {

--- a/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/AbilityWebhookBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/AbilityWebhookBot.java
@@ -20,17 +20,34 @@ public abstract class AbilityWebhookBot extends BaseAbilityBot implements Telegr
 
     private final String botPath;
 
-    protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath, DBContext db, AbilityToggle toggle) {
-        super(telegramClient, botUsername, db, toggle);
+    protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath, DBContext db, AbilityToggle toggle, boolean isDebugMode) {
+        super(telegramClient, botUsername, db, toggle, isDebugMode);
         this.botPath = botPath;
+    }
+
+    protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath, DBContext db, AbilityToggle toggle) {
+        super(telegramClient, botUsername, db, toggle, false);
+        this.botPath = botPath;
+    }
+
+    protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath, AbilityToggle toggle, boolean isDebugMode) {
+        this(telegramClient, botUsername, botPath, onlineInstance(botUsername), toggle, isDebugMode);
     }
 
     protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath, AbilityToggle toggle) {
         this(telegramClient, botUsername, botPath, onlineInstance(botUsername), toggle);
     }
 
+    protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath, DBContext db, boolean isDebugMode) {
+        this(telegramClient, botUsername, botPath, db, new DefaultToggle(), isDebugMode);
+    }
+
     protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath, DBContext db) {
         this(telegramClient, botUsername, botPath, db, new DefaultToggle());
+    }
+
+    protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath, boolean isDebugMode) {
+        this(telegramClient, botUsername, botPath, onlineInstance(botUsername), isDebugMode);
     }
 
     protected AbilityWebhookBot(TelegramClient telegramClient, String botUsername, String botPath) {

--- a/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/BaseAbilityBot.java
@@ -127,14 +127,17 @@ public abstract class BaseAbilityBot implements AbilityExtension, LongPollingSin
     // Reply registry
     private List<Reply> replies;
 
+    private final boolean isDebugMode;
+
     public abstract long creatorId();
 
-    protected BaseAbilityBot(TelegramClient telegramClient, String botUsername, DBContext db, AbilityToggle toggle) {
+    protected BaseAbilityBot(TelegramClient telegramClient, String botUsername, DBContext db, AbilityToggle toggle, boolean isDebugMode) {
         this.telegramClient = telegramClient;
         this.botUsername = botUsername;
         this.db = db;
         this.toggle = toggle;
         this.silent = new SilentSender(telegramClient);
+        this.isDebugMode = isDebugMode;
     }
 
     public void onRegister() {
@@ -634,7 +637,7 @@ public abstract class BaseAbilityBot implements AbilityExtension, LongPollingSin
         } catch(Exception ex) {
             String msg = format("Reply [%s] failed to check for conditions. " +
                     "Make sure you're safeguarding against all possible updates.", name);
-            if (log.isDebugEnabled()) {
+            if (this.isDebugMode) {
                 log.error(msg, ex);
             } else {
                 log.error(msg);


### PR DESCRIPTION
Resolve #886: Add optional 'isDebugMode' parameter to AbilityBot

This change adds a new optional parameter 'isDebugMode' to the AbilityBot class, allowing the method runSilently to enable enhanced logging.
