### PR TITLE
bugfix - ignore undefined json keys

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Document.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Document.java
@@ -1,5 +1,6 @@
 package org.telegram.telegrambots.meta.api.objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -25,6 +26,7 @@ import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 @AllArgsConstructor
 @SuperBuilder
 @Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Document implements BotApiObject {
 
     private static final String FILEID_FIELD = "file_id";


### PR DESCRIPTION
I can see you removed  json ignore annotation for some reason. But, Document stopped working for me (not sure about other objects) because Document had some "thumb" key. In general, I suggest leaving the annotation because if new field added at some point to the api, updated objects stops working for released lib versions