### PR TITLE
BotSession - logs reducing

### DIFF
--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/BotSession.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/BotSession.java
@@ -117,7 +117,7 @@ public class BotSession implements AutoCloseable {
                 }
             } catch (TelegramApiErrorResponseException e) {
                 long backOffMillis = backOff.nextBackOffMillis();
-                log.error("Error received from Telegram GetUpdates Request, retrying in {} millis...", backOffMillis, e);
+                log.error("Error received from Telegram GetUpdates Request, retrying in {} millis...", backOffMillis);
                 try {
                     Thread.sleep(backOffMillis);
                 } catch (InterruptedException ex) {

--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/BotSession.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/BotSession.java
@@ -24,6 +24,7 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.longpolling.interfaces.BackOff;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -117,7 +118,12 @@ public class BotSession implements AutoCloseable {
                 }
             } catch (TelegramApiErrorResponseException e) {
                 long backOffMillis = backOff.nextBackOffMillis();
-                log.error("Error received from Telegram GetUpdates Request, retrying in {} millis...", backOffMillis);
+                if (e.getCause() != null && e.getCause() instanceof SocketException ee) {
+                    log.error("Error received during Telegram GetUpdates Request, some SocketException: {}. Retrying in {} millis...",
+                            ee.getMessage(), backOffMillis);
+                } else {
+					log.error("Error received from Telegram GetUpdates Request, retrying in {} millis...", backOffMillis, e);
+				}
                 try {
                     Thread.sleep(backOffMillis);
                 } catch (InterruptedException ex) {


### PR DESCRIPTION
With long polling and not good network in logs can be a lot of messages with stacktrace. But enough only message, no stacktrace