### PR TITLE
Fix: Remove empty URL validation in SetWebhook to support clearing webhook

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/SetWebhook.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updates/SetWebhook.java
@@ -101,9 +101,6 @@ public class SetWebhook extends PartialBotApiMethod<Boolean> {
 
     @Override
     public void validate() throws TelegramApiValidationException {
-        if (url.isEmpty()) {
-            throw new TelegramApiValidationException("URL parameter can't be empty", this);
-        }
         if (certificate != null) {
             if (!certificate.isNew()) {
                 throw new TelegramApiValidationException("Certificate parameter must be a new file to upload", this);


### PR DESCRIPTION
This PR addresses an issue where the SetWebhook class in the library does not allow an empty URL, despite the [Telegram Bot API documentation](https://core.telegram.org/bots/webhooks#:~:text=Both%20parameters%20for%20the%20setWebhook%20method%20are%20classed%20as%20optional.%20Calling%20the%20method%20with%20an%20empty%20URL%20parameter%20can%20be%20used%20to%20clear%20a%20previously%20set%20webhook.) explicitly stating that an empty URL can be used to clear a previously set webhook.

> Both parameters for the setWebhook method are classed as optional. Calling the method with an empty URL parameter can be used to clear a previously set webhook.