### PR TITLE
Add ability to override TelegramUrl using SpringBoot starter

### DIFF
--- a/telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/TelegramBotStarterConfiguration.java
+++ b/telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/TelegramBotStarterConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.telegram.telegrambots.longpolling.TelegramBotsLongPollingApplication;
+import org.telegram.telegrambots.meta.TelegramUrl;
 
 import java.util.Collections;
 import java.util.List;
@@ -22,8 +23,11 @@ public class TelegramBotStarterConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public TelegramBotInitializer telegramBotInitializer(TelegramBotsLongPollingApplication telegramBotsApplication,
-                                                         ObjectProvider<List<SpringLongPollingBot>> longPollingBots) {
+                                                         ObjectProvider<List<SpringLongPollingBot>> longPollingBots,
+                                                         ObjectProvider<TelegramUrl> telegramUrl) {
         return new TelegramBotInitializer(telegramBotsApplication,
-                longPollingBots.getIfAvailable(Collections::emptyList));
+                longPollingBots.getIfAvailable(Collections::emptyList),
+                telegramUrl.getIfAvailable(() -> TelegramUrl.DEFAULT_URL)
+        );
     }
 }

--- a/telegrambots-springboot-longpolling-starter/src/test/java/org/telegram/telegrambots/longpolling/starter/TestTelegramBotStarterRegistrationHooks.java
+++ b/telegrambots-springboot-longpolling-starter/src/test/java/org/telegram/telegrambots/longpolling/starter/TestTelegramBotStarterRegistrationHooks.java
@@ -37,7 +37,7 @@ class TestTelegramBotStarterRegistrationHooks {
     @Test
     void longPollingBotWithAnnotatedMethodshouldBeCalled() throws TelegramApiException {
 
-        when(mockApplication.registerBot(anyString(), any(LongPollingUpdateConsumer.class))).thenReturn(someBotSession);
+        when(mockApplication.registerBot(anyString(), any(), any(), any(LongPollingUpdateConsumer.class))).thenReturn(someBotSession);
 
         this.contextRunner.withUserConfiguration(LongPollingBotConfig.class)
                 .run((context) -> {
@@ -49,7 +49,7 @@ class TestTelegramBotStarterRegistrationHooks {
                     assertInstanceOf(AnnotatedLongPollingBot.class, bot);
                     assertTrue(((AnnotatedLongPollingBot) bot).isHookCalled());
                     assertEquals(someBotSession, ((AnnotatedLongPollingBot) bot).getHookCalledWithSession());
-                    verify(telegramBotsApi, times(1)).registerBot(eq(bot.getBotToken()), any(LongPollingUpdateConsumer.class));
+                    verify(telegramBotsApi, times(1)).registerBot(eq(bot.getBotToken()), any(), any(), any(LongPollingUpdateConsumer.class));
                     verifyNoMoreInteractions(telegramBotsApi);
                 });
     }

--- a/telegrambots-springboot-longpolling-starter/src/test/java/org/telegram/telegrambots/longpolling/starter/TestTelegramBotStarterWithCustomTelegramUrlConfiguration.java
+++ b/telegrambots-springboot-longpolling-starter/src/test/java/org/telegram/telegrambots/longpolling/starter/TestTelegramBotStarterWithCustomTelegramUrlConfiguration.java
@@ -1,6 +1,7 @@
 package org.telegram.telegrambots.longpolling.starter;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +10,8 @@ import org.telegram.telegrambots.longpolling.TelegramBotsLongPollingApplication;
 import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsumer;
 import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
 import org.telegram.telegrambots.meta.TelegramUrl;
+
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,12 +22,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-class TestTelegramBotStarterConfiguration {
+class TestTelegramBotStarterWithCustomTelegramUrlConfiguration {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withAllowBeanDefinitionOverriding(true)
             .withConfiguration(AutoConfigurations.of(MockTelegramBotsLongPollingApplication.class,
-                                                     TelegramBotStarterConfiguration.class));
+                    TelegramBotStarterConfiguration.class));
 
     @Test
     void createMockTelegramApplicationWithDefaultSettings() {
@@ -32,7 +35,7 @@ class TestTelegramBotStarterConfiguration {
             assertThat(context).hasSingleBean(TelegramBotsLongPollingApplication.class);
             assertThat(context).hasSingleBean(TelegramBotInitializer.class);
             assertThat(context).doesNotHaveBean(SpringLongPollingBot.class);
-            assertThat(context).doesNotHaveBean(TelegramUrl.class);
+            assertThat(context).hasSingleBean(TelegramUrl.class);
             verifyNoMoreInteractions(context.getBean(TelegramBotsLongPollingApplication.class));
         });
     }
@@ -44,9 +47,13 @@ class TestTelegramBotStarterConfiguration {
                     assertThat(context).hasSingleBean(SpringLongPollingBot.class);
 
                     TelegramBotsLongPollingApplication telegramApplication = context.getBean(TelegramBotsLongPollingApplication.class);
+                    TelegramUrl telegramUrl = context.getBean(TelegramUrl.class);
 
-                    verify(telegramApplication, times(1)).registerBot(anyString(), any(), any(), any(LongPollingUpdateConsumer.class));
+                    ArgumentCaptor<Supplier<TelegramUrl>> telegramUrlCaptor = ArgumentCaptor.captor();
+
+                    verify(telegramApplication, times(1)).registerBot(anyString(), telegramUrlCaptor.capture(), any(), any(LongPollingUpdateConsumer.class));
                     verifyNoMoreInteractions(telegramApplication);
+                    assertThat(telegramUrlCaptor.getValue().get()).isEqualTo(telegramUrl);
                 });
     }
 
@@ -56,6 +63,11 @@ class TestTelegramBotStarterConfiguration {
         @Bean
         public TelegramBotsLongPollingApplication telegramBotsApplication() {
             return mock(TelegramBotsLongPollingApplication.class);
+        }
+
+        @Bean
+        public TelegramUrl telegramUrl() {
+            return mock(TelegramUrl.class);
         }
     }
 


### PR DESCRIPTION
This pull request introduces support for custom Telegram URLs in the `telegrambots-springboot-longpolling-starter` module. The most important changes include modifications to the `TelegramBotInitializer` and `TelegramBotStarterConfiguration` classes, as well as updates to the test configurations to accommodate the new functionality.

### Reason

The ability to override the default TelegramUrl is essential for developers who need to work with dedicate test environments.

### Support for Custom Telegram URLs:

* [`telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/TelegramBotInitializer.java`](diffhunk://#diff-bfd13ff8206c8c94cbdab742bb621b7c105e54392949663d1a69020decab1400R8-R9): Added a new constructor to accept a `TelegramUrl` parameter and updated the `afterPropertiesSet` method to use the custom URL. [[1]](diffhunk://#diff-bfd13ff8206c8c94cbdab742bb621b7c105e54392949663d1a69020decab1400R8-R9) [[2]](diffhunk://#diff-bfd13ff8206c8c94cbdab742bb621b7c105e54392949663d1a69020decab1400R22-R41)
* [`telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/TelegramBotStarterConfiguration.java`](diffhunk://#diff-f2825dcfe996da532c8c9ea927dd1302205a7954aab1652e940797c0c3ffa301R9): Modified the `telegramBotInitializer` bean to include the `TelegramUrl` parameter. [[1]](diffhunk://#diff-f2825dcfe996da532c8c9ea927dd1302205a7954aab1652e940797c0c3ffa301R9) [[2]](diffhunk://#diff-f2825dcfe996da532c8c9ea927dd1302205a7954aab1652e940797c0c3ffa301L25-R31)

### Test Updates:

* [`telegrambots-springboot-longpolling-starter/src/test/java/org/telegram/telegrambots/longpolling/starter/TestTelegramBotStarterConfiguration.java`](diffhunk://#diff-8a8a7de9d4f19bcadf47388f738253bee6f831f88c1df00fb11345cf1bfabea1R11): Added assertions to check for the presence of `TelegramUrl` and updated method calls to include the new parameter. [[1]](diffhunk://#diff-8a8a7de9d4f19bcadf47388f738253bee6f831f88c1df00fb11345cf1bfabea1R11) [[2]](diffhunk://#diff-8a8a7de9d4f19bcadf47388f738253bee6f831f88c1df00fb11345cf1bfabea1R35) [[3]](diffhunk://#diff-8a8a7de9d4f19bcadf47388f738253bee6f831f88c1df00fb11345cf1bfabea1L46-R48)
* [`telegrambots-springboot-longpolling-starter/src/test/java/org/telegram/telegrambots/longpolling/starter/TestTelegramBotStarterRegistrationHooks.java`](diffhunk://#diff-6e19005b81beae350ad296dc12a165fda9e3c8b75cc6f05d10f9132c50db6f58L40-R40): Updated mock expectations to include the `TelegramUrl` parameter. [[1]](diffhunk://#diff-6e19005b81beae350ad296dc12a165fda9e3c8b75cc6f05d10f9132c50db6f58L40-R40) [[2]](diffhunk://#diff-6e19005b81beae350ad296dc12a165fda9e3c8b75cc6f05d10f9132c50db6f58L52-R52)
* [`telegrambots-springboot-longpolling-starter/src/test/java/org/telegram/telegrambots/longpolling/starter/TestTelegramBotStarterWithCustomTelegramUrlConfiguration.java`](diffhunk://#diff-ef965d49ed290d4eeaab31c82a875491b9dc9946ff0bb679fef4115d07107864R1-R84): Added a new test class to verify the behavior with custom Telegram URLs.