### PR TITLE
Adding explicit allowedUpdates

### DIFF
--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/TelegramBotsLongPollingApplication.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/TelegramBotsLongPollingApplication.java
@@ -3,6 +3,7 @@ package org.telegram.telegrambots.longpolling;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
+import org.telegram.telegrambots.longpolling.interfaces.BackOff;
 import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsumer;
 import org.telegram.telegrambots.longpolling.util.DefaultGetUpdatesGenerator;
 import org.telegram.telegrambots.longpolling.util.ExponentialBackOff;
@@ -10,8 +11,8 @@ import org.telegram.telegrambots.longpolling.util.TelegramOkHttpClientFactory;
 import org.telegram.telegrambots.meta.TelegramUrl;
 import org.telegram.telegrambots.meta.api.methods.updates.GetUpdates;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
-import org.telegram.telegrambots.longpolling.interfaces.BackOff;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -61,6 +62,10 @@ public class TelegramBotsLongPollingApplication implements AutoCloseable {
 
     public BotSession registerBot(String botToken, LongPollingUpdateConsumer updatesConsumer) throws TelegramApiException {
         return registerBot(botToken, () -> TelegramUrl.DEFAULT_URL, new DefaultGetUpdatesGenerator(), updatesConsumer);
+    }
+
+    public BotSession registerBot(String botToken, LongPollingUpdateConsumer updatesConsumer, List<String> allowedUpdates) throws TelegramApiException {
+        return registerBot(botToken, () -> TelegramUrl.DEFAULT_URL, new DefaultGetUpdatesGenerator(allowedUpdates), updatesConsumer);
     }
 
     public BotSession registerBot(String botToken,

--- a/telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/SpringLongPollingBot.java
+++ b/telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/SpringLongPollingBot.java
@@ -2,7 +2,13 @@ package org.telegram.telegrambots.longpolling.starter;
 
 import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsumer;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public interface SpringLongPollingBot {
     String getBotToken();
     LongPollingUpdateConsumer getUpdatesConsumer();
+    default List<String> getAllowedUpdates() {
+        return new ArrayList<>();
+    }
 }

--- a/telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/TelegramBotInitializer.java
+++ b/telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/TelegramBotInitializer.java
@@ -28,7 +28,7 @@ public class TelegramBotInitializer implements InitializingBean {
     public void afterPropertiesSet()  {
         try {
             for (SpringLongPollingBot longPollingBot : longPollingBots) {
-                BotSession session = telegramBotsApplication.registerBot(longPollingBot.getBotToken(), longPollingBot.getUpdatesConsumer());
+                BotSession session = telegramBotsApplication.registerBot(longPollingBot.getBotToken(), longPollingBot.getUpdatesConsumer(), longPollingBot.getAllowedUpdates());
                 handleAfterRegistrationHook(longPollingBot, session);
             }
         } catch (TelegramApiException e) {


### PR DESCRIPTION
1. Created another constructor in the [TelegramBotsLongPollingApplication ](https://github.com/rubenlagus/TelegramBots/blob/master/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/TelegramBotsLongPollingApplication.java) class, which additionally accepts a List<String> containing allowedUpdates, which passes allowedUpdates to the [DefaultGetUpdatesGenerator](https://github.com/rubenlagus/TelegramBots/blob/master/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/util/DefaultGetUpdatesGenerator.java).
2. In [SpringLongPollingBot ](https://github.com/rubenlagus/TelegramBots/blob/master/telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/SpringLongPollingBot.java) added an optional method that sets allowedUpdates in a Spring Boot application. In [TelegramBotInitializer ](https://github.com/rubenlagus/TelegramBots/blob/master/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/TelegramBotsLongPollingApplication.java) changed the constructor of the [TelegramBotInitializer ](https://github.com/rubenlagus/TelegramBots/blob/master/telegrambots-springboot-longpolling-starter/src/main/java/org/telegram/telegrambots/longpolling/starter/TelegramBotInitializer.java) class to which the afterPropertiesSet method is accessed.