### PR TITLE
Fix potentially nondeterministic TestDeleteStory.testJsonSerialization

### DIFF
--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/stories/TestDeleteStory.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/methods/stories/TestDeleteStory.java
@@ -1,5 +1,7 @@
 package org.telegram.telegrambots.meta.api.methods.stories;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
@@ -13,12 +15,14 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @version 9.0
  */
 public class TestDeleteStory {
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = JsonMapper.builder()
+            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .build();
 
     @Test
     public void testJsonSerialization() {
         try {
-            String expectedJson = "{\"business_connection_id\":\"12345\",\"story_id\":67890,\"method\":\"deleteStory\"}";
+            String expectedJson = "{\"business_connection_id\":\"12345\",\"method\":\"deleteStory\",\"story_id\":67890}";
             
             DeleteStory deleteStory = DeleteStory.builder()
                     .businessConnectionId("12345")


### PR DESCRIPTION
### Issue

Hello, I noticed that the unit test `TestDeleteStory.testJsonSerialization` relies on a Jackson ObjectMapper to serialize the `deleteStory` object. However, the ObjectMapper's JSON parameter ordering is technically not guaranteed without explicit configuration, thus the test can technically fail occasionally. Though it's likely stable now, it might be beneficial to address this just in case the underlying environment ends up changing in the future.

This test was detected via by the [Nondex tool](https://github.com/TestingResearchIllinois/NonDex), which flags Java tests that are potentially nondeterministic due to underlying assumptions regarding the Java API. To see the Nondex output for this test class, you can run:

```
mvn -pl telegrambots-meta edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="org.telegram.telegrambots.meta.api.methods.stories.TestDeleteStory"
```

### Potential Fix

Jackson does provide some config options to set the parameter ordering in the ObjectMapper. Here, I configure the ObjectMapper to sort the parameters alphabetically using Jackson's [`MapperFeature.SORT_PROPERTIES_ALPHABETICALLY`](https://javadoc.io/static/com.fasterxml.jackson.core/jackson-databind/2.3.1/com/fasterxml/jackson/databind/MapperFeature.html#SORT_PROPERTIES_ALPHABETICALLY), and then I manually change the parameter ordering to alphabetical in the expected JSON string. I'm under the assumption the JSON parameter ordering doesn't matter for this unit test, but please let me know if that's not the case. 

The tests still pass (verified with `mvn clean test`), and Nondex also shows a passing result now.

There are a few other tests I found with a similar issue and fix, but I wanted to keep this PR very small to get some initial feedback and suggestions. Thank you!