### PR TITLE
Fix (#1531) AbilityBot ignoring updates from Channels 

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/BaseAbilityBot.java
@@ -210,6 +210,7 @@ public abstract class BaseAbilityBot implements AbilityExtension, LongPollingSin
     public Privacy getPrivacy(Update update, long id) {
         return isCreator(id) ?
             Privacy.CREATOR : isAdmin(id) ?
+            Privacy.ADMIN : (update.hasChannelPost() || update.hasEditedChannelPost()) ?
             Privacy.ADMIN : (isGroupUpdate(update) || isSuperGroupUpdate(update)) && isGroupAdmin(update, id) ?
             Privacy.GROUP_ADMIN : Privacy.PUBLIC;
     }
@@ -541,8 +542,8 @@ public abstract class BaseAbilityBot implements AbilityExtension, LongPollingSin
     Trio<Update, Ability, String[]> getAbility(Update update) {
         // Handle updates without messages
         // Passing through this function means that the global flags have passed
-        Message msg = update.getMessage();
-        if (!update.hasMessage() || !msg.hasText())
+        Message msg = AbilityUtils.getMessage(update);
+        if (msg == null || !msg.hasText())
             return Trio.of(update, abilities.get(DEFAULT), new String[]{});
 
         Ability ability;
@@ -602,6 +603,7 @@ public abstract class BaseAbilityBot implements AbilityExtension, LongPollingSin
     private boolean hasUser(Update update) {
         // Valid updates without users should return an empty user
         // Updates that are not recognized by the getUser method will throw an exception
+        if (update.hasChannelPost() || update.hasEditedChannelPost()) return true;
         return !AbilityUtils.getUser(update).equals(EMPTY_USER);
     }
 

--- a/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/util/AbilityUtils.java
@@ -6,6 +6,7 @@ import org.telegram.telegrambots.abilitybots.api.objects.MessageContext;
 import org.telegram.telegrambots.abilitybots.api.objects.Flag;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
 
 import java.text.MessageFormat;
 import java.util.Locale;
@@ -325,5 +326,23 @@ public final class AbilityUtils {
   public static boolean isValidCommandName(String commandName){
     if (commandName == null || commandName.length() > 31) return false;
     return commandName.matches("[A-Za-z_0-9]+");
+  }
+
+  /**
+   * Extracts the Message from the Update regardless of the type (Message, ChannelPost, etc).
+   * @param update Telegram {@link Update}
+   * @return Message object or null if not found
+   */
+  public static Message getMessage(Update update){
+    if (Flag.MESSAGE.test(update)) {
+      return update.getMessage();
+    } else if (Flag.EDITED_MESSAGE.test(update)) {
+      return update.getEditedMessage();
+    } else if (Flag.CHANNEL_POST.test(update)){
+      return update.getChannelPost();
+    } else if (Flag.EDITED_CHANNEL_POST.test(update)) {
+      return update.getEditedChannelPost();
+    }
+    return null;
   }
 }

--- a/telegrambots-abilities/src/test/java/org/telegram/telegrambots/abilitybots/api/bot/TestAbilityBotChannel.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/telegrambots/abilitybots/api/bot/TestAbilityBotChannel.java
@@ -1,0 +1,107 @@
+package org.telegram.telegrambots.abilitybots.api.bot;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.abilitybots.api.db.DBContext;
+import org.telegram.telegrambots.abilitybots.api.objects.Ability;
+import org.telegram.telegrambots.abilitybots.api.objects.Locality;
+import org.telegram.telegrambots.abilitybots.api.objects.Privacy;
+import org.telegram.telegrambots.abilitybots.api.sender.SilentSender;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.io.IOException;
+
+import org.telegram.telegrambots.abilitybots.api.toggle.BareboneToggle;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.telegram.telegrambots.abilitybots.api.db.MapDBContext.offlineInstance;
+
+public class TestAbilityBotChannel {
+    private ChannelAbilityBot bot;
+    private DBContext db;
+    private TelegramClient telegramClient;
+    private SilentSender silent;
+
+    @BeforeEach
+    void setUp() {
+        telegramClient = mock(TelegramClient.class);
+        silent = spy(new SilentSender(telegramClient));
+
+        db = offlineInstance("db");
+        bot = new ChannelAbilityBot(telegramClient, EMPTY, db);
+        bot.silent = silent;
+        bot.onRegister();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        db.clear();
+        db.close();
+    }
+
+    @Test
+    void canTriggerAbilityInChannel() {
+        Update update = mock(Update.class);
+        Message message = mock(Message.class);
+
+        when(update.hasChannelPost()).thenReturn(true);
+        when(update.getChannelPost()).thenReturn(message);
+        when(message.getChatId()).thenReturn(12345L);
+        when(message.hasText()).thenReturn(true);
+        when(message.getText()).thenReturn("/channel_msg_test");
+        when(message.getFrom()).thenReturn(null); // Channel posts dosent have user
+
+        bot.consume(update);
+
+        verify(silent, times(1)).send("testtt", 12345L);
+    }
+
+    @Test
+    void canTriggerAbilityInEditedChannelPost() {
+        Update update = mock(Update.class);
+        Message message = mock(Message.class);
+
+        when(update.hasChannelPost()).thenReturn(false);
+        when(update.hasEditedChannelPost()).thenReturn(true);
+        when(update.getEditedChannelPost()).thenReturn(message);
+
+        when(message.getChatId()).thenReturn(12345L);
+        when(message.hasText()).thenReturn(true);
+        when(message.getText()).thenReturn("/channel_msg_test");
+        when(message.getFrom()).thenReturn(null);
+
+        bot.consume(update);
+
+        verify(silent, times(1)).send("testtt", 12345L);
+    }
+
+    private static class ChannelAbilityBot extends BaseAbilityBot {
+        public ChannelAbilityBot(TelegramClient telegramClient, String botUsername, DBContext db) {
+            super(telegramClient, botUsername, db, new BareboneToggle());
+        }
+
+        @Override
+        public long creatorId() {
+            return 228322L;
+        }
+
+        public Ability test() {
+            return Ability.builder()
+                    .name("channel_msg_test")
+                    .privacy(Privacy.PUBLIC)
+                    .locality(Locality.ALL)
+                    .action(ctx -> {
+                        silent.send("testtt", ctx.chatId());
+                    })
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fix of the issue where `AbilityBot` ignored updates from Channels (Issue #1531).

### Changes
1. **BaseAbilityBot:**
   - Updated `getAbility` to strictly check for `ChannelPost` and `EditedChannelPost`.
   - Updated `hasUser` to allow updates from channels (where user is empty).
   - Updated `getPrivacy` to assign `Privacy.GROUP_ADMIN` rights to channel posts (only admins are able to post on channels).

2. **AbilityUtils:**
   - Added `getMessage(Update update)` helper to abstract update type extraction (onyl for Message and ChannelPost for now). 

3. **Tests:**
   - Added unit tests in `TestAbilityBotChannel.` Cases:  channel posts and edited channel posts.

### Issueu #1531