### PR TITLE
Feature #1532: Add protected hooks for handling ability restrictions (Input, Locality, Privacy)

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/BaseAbilityBot.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/bot/BaseAbilityBot.java
@@ -489,13 +489,30 @@ public abstract class BaseAbilityBot implements AbilityExtension, LongPollingSin
         boolean isOk = abilityTokens == 0 || (tokens.length > 0 && tokens.length == abilityTokens);
 
         if (!isOk)
-            silent.send(
-                    getLocalizedMessage(
-                            CHECK_INPUT_FAIL,
-                            AbilityUtils.getUser(trio.a()).getLanguageCode(),
-                            abilityTokens, abilityTokens == 1 ? "input" : "inputs"),
-                    getChatId(trio.a()));
+            onInputViolation(trio.a(), trio.b());
         return isOk;
+    }
+
+    /**
+     * Called when user input doesn't match the required number of arguments for the ability.
+     * <p>
+     *  Deafult implementation sends  localized
+     * {@link org.telegram.telegrambots.abilitybots.api.util.AbilityMessageCodes#CHECK_INPUT_FAIL}
+     * message to the user.
+     * <p>
+     * Override this method to custom handle input errors (e.g. send usage example or do nothing).
+     *
+     * @param update  update that caused the violation
+     * @param ability ability that was attempted to be executed
+     */
+    protected void onInputViolation(Update update, Ability ability) {
+        int abilityTokens = ability.tokens();
+        silent.send(
+                getLocalizedMessage(
+                        CHECK_INPUT_FAIL,
+                        AbilityUtils.getUser(update).getLanguageCode(),
+                        abilityTokens, abilityTokens == 1 ? "input" : "inputs"),
+                getChatId(update));
     }
 
     boolean checkLocality(Trio<Update, Ability, String[]> trio) {
@@ -506,13 +523,30 @@ public abstract class BaseAbilityBot implements AbilityExtension, LongPollingSin
         boolean isOk = abilityLocality == Locality.ALL || locality == abilityLocality;
 
         if (!isOk)
-            silent.send(
-                    getLocalizedMessage(
-                            CHECK_LOCALITY_FAIL,
-                            AbilityUtils.getUser(trio.a()).getLanguageCode(),
-                            abilityLocality.toString().toLowerCase()),
-                    getChatId(trio.a()));
+            onLocalityViolation(trio.a(), trio.b());
         return isOk;
+    }
+
+    /**
+     * Called when the user tries to use ability in locality that isn't allowed
+     * (e.g. using {@link Locality#GROUP} ability in private chat).
+     * <p>
+     * Deafult implementation sends localized
+     * {@link org.telegram.telegrambots.abilitybots.api.util.AbilityMessageCodes#CHECK_LOCALITY_FAIL}
+     * message to the user.
+     * <p>
+     * Override this method to custom handle locality errors (e.g. silent ignore in groups).
+     *
+     * @param update   update that caused the violation
+     * @param ability ability that was attempted to be executed
+     */
+    protected void onLocalityViolation(Update update, Ability ability) {
+        silent.send(
+                getLocalizedMessage(
+                        CHECK_LOCALITY_FAIL,
+                        AbilityUtils.getUser(update).getLanguageCode(),
+                        ability.locality().toString().toLowerCase()),
+                getChatId(update));
     }
 
     boolean checkPrivacy(Trio<Update, Ability, String[]> trio) {
@@ -526,12 +560,28 @@ public abstract class BaseAbilityBot implements AbilityExtension, LongPollingSin
         boolean isOk = privacy.compareTo(trio.b().privacy()) >= 0;
 
         if (!isOk)
-            silent.send(
-                    getLocalizedMessage(
-                            CHECK_PRIVACY_FAIL,
-                            AbilityUtils.getUser(trio.a()).getLanguageCode()),
-                    getChatId(trio.a()));
+            onPrivacyViolation(trio.a(), trio.b());
         return isOk;
+    }
+
+    /**
+     * Called when the user doesn't have required {@link Privacy} level to execute the ability.
+     * <p>
+     * Deafult implementation sends localized
+     * {@link org.telegram.telegrambots.abilitybots.api.util.AbilityMessageCodes#CHECK_PRIVACY_FAIL}
+     * message to the user.
+     * <p>
+     * Override this method to custom handle privacy errors (e.g. log the attempt or ban the user).
+     *
+     * @param update  update that caused the violation
+     * @param ability ability that was attempted to be executed
+     */
+    protected void onPrivacyViolation(Update update, Ability ability) {
+        silent.send(
+                getLocalizedMessage(
+                        CHECK_PRIVACY_FAIL,
+                        AbilityUtils.getUser(update).getLanguageCode()),
+                getChatId(update));
     }
 
     boolean validateAbility(Trio<Update, Ability, String[]> trio) {


### PR DESCRIPTION
Fixes: #1532
### Description
Original enhancement request is to add custom message in case of violation Locality. I moved handling input, locality and privacy violations to separate protected methods so they can be overriden

### Changes
1. **BaseAbilityBot:**
   - Refactored `checkInput`,` checkLocality`, and `checkPrivacy` to delegate error handling to new protected methods instead of hardcoded logic.
   - Added `protected void onInputViolation(Update, Ability)` to customize reaction to invalid arguments
   - Added `protected void onLocalityViolation(Update, Ability)` to customize reaction to locality violations (e.g. Group vs Private).
   - Added `protected void onPrivacyViolation(Update, Ability)` to customize reaction to insufficient permissions.


### Example usage
Developer can now override protected hooks to customize behavior:

```java
@Override
protected void onLocalityViolation(Update update, Ability ability) {
    // Send custom message or silent ignore or ban the punk idk
    silent.send("Custom error message", getChatId(update));
}
```
### Issue #1532