### PR TITLE
Fix API methods from 8.3 and 9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.telegram</groupId>
     <artifactId>Bots</artifactId>
     <packaging>pom</packaging>
-    <version>9.1.0</version>
+    <version>9.2.0</version>
 
     <modules>
         <module>telegrambots-meta</module>
@@ -67,11 +67,11 @@
         <slf4j.version>2.0.12</slf4j.version>
         <lombok.version>1.18.34</lombok.version>
         <guava.version>33.2.1-jre</guava.version>
-        <commons-lang.version>3.14.0</commons-lang.version>
+        <commons-lang.version>3.18.0</commons-lang.version>
         <commons-io.version>2.16.1</commons-io.version>
         <okhttp.version>4.12.0</okhttp.version>
 
-        <junit.version>5.10.3</junit.version>
+        <junit.version>5.12.2</junit.version>
         <mockito.version>5.12.0</mockito.version>
         <mockitojupiter.version>5.12.0</mockitojupiter.version>
         <awaitability.version>4.2.1</awaitability.version>

--- a/telegrambots-abilities/pom.xml
+++ b/telegrambots-abilities/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <artifactId>telegrambots-abilities</artifactId>
@@ -93,12 +93,12 @@
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots-webhook</artifactId>
-            <version>9.1.0</version>
+            <version>9.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots-longpolling</artifactId>
-            <version>9.1.0</version>
+            <version>9.2.0</version>
         </dependency>
 
         <dependency>

--- a/telegrambots-client-jetty-adapter/pom.xml
+++ b/telegrambots-client-jetty-adapter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <name>Telegram Bots Client Jetty HttpClient adapter</name>

--- a/telegrambots-client-jetty-adapter/src/main/java/org/telegram/telegrambots/client/jetty/JettyTelegramClient.java
+++ b/telegrambots-client-jetty-adapter/src/main/java/org/telegram/telegrambots/client/jetty/JettyTelegramClient.java
@@ -349,6 +349,7 @@ public class JettyTelegramClient extends AbstractTelegramClient {
                     .addPart(SendMediaGroup.BUSINESS_CONNECTION_ID_FIELD, sendMediaGroup.getBusinessConnectionId())
                     .addPart(SendMediaGroup.MESSAGE_EFFECT_ID_FIELD, sendMediaGroup.getMessageEffectId())
                     .addPart(SendMediaGroup.ALLOW_PAID_BROADCAST_FIELD, sendMediaGroup.getAllowSendingWithoutReply())
+                    .addPart(SendMediaGroup.DIRECT_MESSAGES_TOPIC_ID_FIELD, sendMediaGroup.getDirectMessagesTopicId())
                     .addJsonPart(SendMediaGroup.REPLY_MARKUP_FIELD, sendMediaGroup.getReplyMarkup())
                     .addJsonPart(SendMediaGroup.REPLY_PARAMETERS_FIELD, sendMediaGroup.getReplyParameters());
 
@@ -639,6 +640,8 @@ public class JettyTelegramClient extends AbstractTelegramClient {
                     .addPart(SendMediaBotMethod.PROTECT_CONTENT_FIELD, method.getProtectContent())
                     .addPart(SendMediaBotMethod.ALLOW_SENDING_WITHOUT_REPLY_FIELD, method.getAllowSendingWithoutReply())
                     .addPart(SendMediaBotMethod.MESSAGE_EFFECT_ID_FIELD, method.getMessageEffectId())
+                    .addPart(SendMediaBotMethod.DIRECT_MESSAGES_TOPIC_ID_FIELD, method.getDirectMessagesTopicId())
+                    .addPart(SendMediaBotMethod.SUGGESTED_POST_PARAMETERS_FIELD, method.getSuggestedPostParameters())
                     .addJsonPart(SendMediaBotMethod.REPLY_PARAMETERS_FIELD, method.getReplyParameters())
                     .addJsonPart(SendMediaBotMethod.REPLY_MARKUP_FIELD, method.getReplyMarkup());
 

--- a/telegrambots-client/pom.xml
+++ b/telegrambots-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <name>Telegram Bots Client</name>

--- a/telegrambots-client/src/main/java/org/telegram/telegrambots/client/okhttp/OkHttpTelegramClient.java
+++ b/telegrambots-client/src/main/java/org/telegram/telegrambots/client/okhttp/OkHttpTelegramClient.java
@@ -341,6 +341,7 @@ public class OkHttpTelegramClient extends AbstractTelegramClient {
                     .addPart(SendMediaGroup.BUSINESS_CONNECTION_ID_FIELD, sendMediaGroup.getBusinessConnectionId())
                     .addPart(SendMediaGroup.MESSAGE_EFFECT_ID_FIELD, sendMediaGroup.getMessageEffectId())
                     .addPart(SendMediaGroup.ALLOW_PAID_BROADCAST_FIELD, sendMediaGroup.getAllowSendingWithoutReply())
+                    .addPart(SendMediaGroup.DIRECT_MESSAGES_TOPIC_ID_FIELD, sendMediaGroup.getDirectMessagesTopicId())
                     .addJsonPart(SendMediaGroup.REPLY_MARKUP_FIELD, sendMediaGroup.getReplyMarkup())
                     .addJsonPart(SendMediaGroup.REPLY_PARAMETERS_FIELD, sendMediaGroup.getReplyParameters());
 
@@ -632,6 +633,8 @@ public class OkHttpTelegramClient extends AbstractTelegramClient {
                     .addPart(SendMediaBotMethod.ALLOW_SENDING_WITHOUT_REPLY_FIELD, method.getAllowSendingWithoutReply())
                     .addPart(SendMediaBotMethod.MESSAGE_EFFECT_ID_FIELD, method.getMessageEffectId())
                     .addPart(SendMediaBotMethod.ALLOW_PAID_BROADCAST_FIELD, method.getAllowPaidBroadcast())
+                    .addPart(SendMediaBotMethod.DIRECT_MESSAGES_TOPIC_ID_FIELD, method.getDirectMessagesTopicId())
+                    .addPart(SendMediaBotMethod.SUGGESTED_POST_PARAMETERS_FIELD, method.getSuggestedPostParameters())
                     .addJsonPart(SendMediaBotMethod.REPLY_PARAMETERS_FIELD, method.getReplyParameters())
                     .addJsonPart(SendMediaBotMethod.REPLY_MARKUP_FIELD, method.getReplyMarkup());
 

--- a/telegrambots-extensions/README.md
+++ b/telegrambots-extensions/README.md
@@ -16,12 +16,12 @@ Just import add the library to your project with one of these options:
     <dependency>
         <groupId>org.telegram</groupId>
         <artifactId>telegrambots-extensions</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </dependency>
 ```
 
    2. Using Gradle:
 
 ```gradle
-    implementation 'org.telegram:telegrambots-extensions:9.1.0'
+    implementation 'org.telegram:telegrambots-extensions:9.2.0'
 ```

--- a/telegrambots-extensions/pom.xml
+++ b/telegrambots-extensions/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <artifactId>telegrambots-extensions</artifactId>
@@ -78,12 +78,12 @@
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots-webhook</artifactId>
-            <version>9.1.0</version>
+            <version>9.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.telegram</groupId>
             <artifactId>telegrambots-longpolling</artifactId>
-            <version>9.1.0</version>
+            <version>9.2.0</version>
         </dependency>
 
         <dependency>

--- a/telegrambots-longpolling/pom.xml
+++ b/telegrambots-longpolling/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <artifactId>telegrambots-longpolling</artifactId>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.18</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/telegrambots-meta/pom.xml
+++ b/telegrambots-meta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <artifactId>telegrambots-meta</artifactId>

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessage.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.MessageId;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -50,6 +51,7 @@ public class CopyMessage extends BotApiMethod<MessageId> {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String FROM_CHAT_ID_FIELD = "from_chat_id";
     private static final String MESSAGE_ID_FIELD = "message_id";
     private static final String CAPTION_FIELD = "caption";
@@ -64,6 +66,7 @@ public class CopyMessage extends BotApiMethod<MessageId> {
     private static final String SHOW_CAPTION_ABOVE_MEDIA_FIELD = "show_caption_above_media";
     private static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
     private static final String VIDEO_START_TIMESTAMP_FIELD = "video_start_timestamp";
+    private static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull
@@ -74,6 +77,13 @@ public class CopyMessage extends BotApiMethod<MessageId> {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     @JsonProperty(FROM_CHAT_ID_FIELD)
     @NonNull
     private String fromChatId; ///< Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
@@ -127,6 +137,14 @@ public class CopyMessage extends BotApiMethod<MessageId> {
      */
     @JsonProperty(VIDEO_START_TIMESTAMP_FIELD)
     private Boolean videoStartTimestamp;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    @JsonProperty(SUGGESTED_POST_PARAMETERS_FIELD)
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessage.java
@@ -136,7 +136,7 @@ public class CopyMessage extends BotApiMethod<MessageId> {
      * New start timestamp for the copied video in the message
      */
     @JsonProperty(VIDEO_START_TIMESTAMP_FIELD)
-    private Boolean videoStartTimestamp;
+    private Integer videoStartTimestamp;
 
     /**
      * Optional

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessages.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/CopyMessages.java
@@ -52,6 +52,7 @@ public class CopyMessages extends BotApiMethod<ArrayList<MessageId>> {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String FROM_CHAT_ID_FIELD = "from_chat_id";
     private static final String MESSAGE_IDS_FIELD = "message_ids";
     private static final String DISABLE_NOTIFICATION_FIELD = "disable_notification";
@@ -70,6 +71,13 @@ public class CopyMessages extends BotApiMethod<ArrayList<MessageId>> {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the messages will be sent;
+     * required if the messages are sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     /**
      * Unique identifier for the chat where the original messages were sent (or channel username in the format @channelusername)
      */

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessage.java
@@ -14,6 +14,7 @@ import lombok.experimental.SuperBuilder;
 import lombok.experimental.Tolerate;
 import lombok.extern.jackson.Jacksonized;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
 
@@ -40,11 +41,13 @@ public class ForwardMessage extends BotApiMethodMessage {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String FROM_CHAT_ID_FIELD = "from_chat_id";
     private static final String MESSAGE_ID_FIELD = "message_id";
     private static final String DISABLE_NOTIFICATION_FIELD = "disable_notification";
     private static final String PROTECT_CONTENT_FIELD = "protect_content";
     private static final String VIDEO_START_TIMESTAMP_FIELD = "video_start_timestamp";
+    private static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull
@@ -55,6 +58,13 @@ public class ForwardMessage extends BotApiMethodMessage {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be forwarded;
+     * required if the message is forwarded to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     @JsonProperty(FROM_CHAT_ID_FIELD)
     @NonNull
     private String fromChatId; ///< Unique identifier for the chat where the original message was sent — User or GroupChat id
@@ -77,6 +87,14 @@ public class ForwardMessage extends BotApiMethodMessage {
      */
     @JsonProperty(VIDEO_START_TIMESTAMP_FIELD)
     private Boolean videoStartTimestamp;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    @JsonProperty(SUGGESTED_POST_PARAMETERS_FIELD)
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessage.java
@@ -86,7 +86,7 @@ public class ForwardMessage extends BotApiMethodMessage {
      * New start timestamp for the copied video in the message
      */
     @JsonProperty(VIDEO_START_TIMESTAMP_FIELD)
-    private Boolean videoStartTimestamp;
+    private Integer videoStartTimestamp;
 
     /**
      * Optional

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessages.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/ForwardMessages.java
@@ -48,6 +48,7 @@ public class ForwardMessages extends BotApiMethod<ArrayList<MessageId>> {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String FROM_CHAT_ID_FIELD = "from_chat_id";
     private static final String MESSAGE_IDS_FIELD = "message_ids";
     private static final String DISABLE_NOTIFICATION_FIELD = "disable_notification";
@@ -65,6 +66,13 @@ public class ForwardMessages extends BotApiMethod<ArrayList<MessageId>> {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the messages will be forwarded;
+     * required if the messages are forwarded to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     /**
      * Unique identifier for the chat where the original messages were sent (or channel username in the format @channelusername)
      */

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/LeaveChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/LeaveChat.java
@@ -20,6 +20,7 @@ import org.telegram.telegrambots.meta.util.Validations;
  * @author Ruben Bermudez
  * @version 1.0
  * Use this method for your bot to leave a group, supergroup or channel. Returns True on success.
+ * Channel direct messages chats aren't supported; leave the corresponding channel instead.
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
@@ -37,7 +38,7 @@ public class LeaveChat extends BotApiMethodBoolean {
 
     @JsonProperty(CHATID_FIELD)
     @NonNull
-    private String chatId; ///< Unique identifier for the chat to send the message to (Or username for channels)
+    private String chatId; ///< Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername). Channel direct messages chats aren't supported; leave the corresponding channel instead.
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/PromoteChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/groupadministration/PromoteChatMember.java
@@ -55,6 +55,7 @@ public class PromoteChatMember extends BotApiMethodBoolean {
     private static final String CAN_POST_STORIES_FIELD = "can_post_stories";
     private static final String CAN_EDIT_STORIES_FIELD = "can_edit_stories";
     private static final String CAN_DELETE_STORIES_FIELD = "can_delete_stories";
+    private static final String CAN_MANAGE_DIRECT_MESSAGES_FIELD = "can_manage_direct_messages";
 
     @JsonProperty(CHATID_FIELD)
     @NonNull
@@ -125,6 +126,13 @@ public class PromoteChatMember extends BotApiMethodBoolean {
      */
     @JsonProperty(CAN_DELETE_STORIES_FIELD)
     private Boolean canDeleteStories;
+
+    /**
+     * Optional
+     * Pass True if the administrator can manage direct messages within the channel and decline suggested posts; for channels only
+     */
+    @JsonProperty(CAN_MANAGE_DIRECT_MESSAGES_FIELD)
+    private Boolean canManageDirectMessages;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/SendInvoice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/invoices/SendInvoice.java
@@ -19,6 +19,7 @@ import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMess
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.payments.LabeledPrice;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
 
@@ -44,6 +45,7 @@ public class SendInvoice extends BotApiMethodMessage {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String TITLE_FIELD = "title";
     private static final String DESCRIPTION_FIELD = "description";
     private static final String PAYLOAD_FIELD = "payload";
@@ -73,6 +75,7 @@ public class SendInvoice extends BotApiMethodMessage {
     private static final String REPLY_PARAMETERS_FIELD = "reply_parameters";
     private static final String MESSAGE_EFFECT_ID_FIELD = "message_effect_id";
     private static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
+    private static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     /**
      * Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -86,6 +89,13 @@ public class SendInvoice extends BotApiMethodMessage {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     /**
      * Product name
      */
@@ -285,6 +295,13 @@ public class SendInvoice extends BotApiMethodMessage {
      */
     @JsonProperty(ALLOW_PAID_BROADCAST_FIELD)
     private Boolean allowPaidBroadcast;
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    @JsonProperty(SUGGESTED_POST_PARAMETERS_FIELD)
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/PinChatMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/PinChatMessage.java
@@ -21,10 +21,10 @@ import org.telegram.telegrambots.meta.util.Validations;
  * @author Ruben Bermudez
  * @version 3.1
  * Use this method to add a message to the list of pinned messages in a chat.
+ * In private chats and channel direct messages chats, all non-service messages can be pinned.
+ * Conversely, the bot must be an administrator with the 'can_pin_messages' right or the 'can_edit_messages' right
+ * to pin messages in groups and channels respectively.
  * Returns True on success.
- *
- * @apiNote If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must
- * have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages' admin right in a channel.
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
@@ -46,7 +46,9 @@ public class PinChatMessage extends BotApiMethodBoolean {
 
     /**
      * Required.
-     * Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     * Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+     * In private chats and channel direct messages chats, all non-service messages can be pinned.
+     * In groups and channels, the bot must be an administrator with appropriate rights.
      */
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinAllChatMessages.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinAllChatMessages.java
@@ -20,11 +20,10 @@ import org.telegram.telegrambots.meta.util.Validations;
  * @author Ruben Bermudez
  * @version 3.1
  * Use this method to clear the list of pinned messages in a chat.
+ * In private chats and channel direct messages chats, no additional rights are required to unpin all pinned messages.
+ * Conversely, the bot must be an administrator with the 'can_pin_messages' right or the 'can_edit_messages' right
+ * to unpin all pinned messages in groups and channels respectively.
  * Returns True on success.
- *
- * @apiNote If the chat is not a private chat, the bot must be an administrator in the chat for this to
- * work and must have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages' admin
- * right in a channel.
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
@@ -42,7 +41,7 @@ public class UnpinAllChatMessages extends BotApiMethodBoolean {
 
     @JsonProperty(CHATID_FIELD)
     @NonNull
-    private String chatId; ///< Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+    private String chatId; ///< Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername). In private chats and channel direct messages chats, no additional rights are required.
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinChatMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/pinnedmessages/UnpinChatMessage.java
@@ -21,11 +21,10 @@ import org.telegram.telegrambots.meta.util.Validations;
  * @author Ruben Bermudez
  * @version 3.1
  * Use this method to remove a message from the list of pinned messages in a chat.
+ * In private chats and channel direct messages chats, all messages can be unpinned.
+ * Conversely, the bot must be an administrator with the 'can_pin_messages' right or the 'can_edit_messages' right
+ * to unpin messages in groups and channels respectively.
  * Returns True on success.
- *
- * @apiNote If the chat is not a private chat, the bot must be an administrator in the chat for this to work
- * and must have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages'
- * admin right in a channel.
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
@@ -46,7 +45,9 @@ public class UnpinChatMessage extends BotApiMethodBoolean {
 
     /**
      * Required.
-     * Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     * Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+     * In private chats and channel direct messages chats, all messages can be unpinned.
+     * In groups and channels, the bot must be an administrator with appropriate rights.
      */
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/SendPoll.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/polls/SendPoll.java
@@ -29,6 +29,7 @@ import java.util.List;
  * @version 1.0
  * Use this method to send a native poll.
  * A native poll can't be sent to a private chat.
+ * Polls can't be sent to channel direct messages chats.
  * <p>
  * On success, the sent Message is returned.
  */
@@ -74,6 +75,7 @@ public class SendPoll extends BotApiMethodMessage {
     /**
      * Unique identifier for the target chat or username of the target channel (in the format @channelusername).
      * A native poll can't be sent to a private chat.
+     * Polls can't be sent to channel direct messages chats.
      */
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAnimation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAnimation.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -67,6 +68,12 @@ public class SendAnimation extends SendMediaBotMethod<Message> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
 
     /**
      * Animation to send. Pass a file_id as String to send an animation that exists on the
@@ -173,6 +180,13 @@ public class SendAnimation extends SendMediaBotMethod<Message> {
      * The relevant Stars will be withdrawn from the bot's balance
      */
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAudio.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendAudio.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -63,6 +64,12 @@ public class SendAudio extends SendMediaBotMethod<Message> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     @NonNull
     private InputFile audio; ///< Audio file to send. file_id as String to resend an audio that is already on the Telegram servers or Url to upload it
     private Integer replyToMessageId; ///< Optional. If the message is a reply, ID of the original message
@@ -113,6 +120,13 @@ public class SendAudio extends SendMediaBotMethod<Message> {
      * The relevant Stars will be withdrawn from the bot's balance
      */
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendChatAction.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendChatAction.java
@@ -24,6 +24,7 @@ import org.telegram.telegrambots.meta.util.Validations;
  * Use this method when you need to tell the user that something is happening on the bot's
  * side. The status is set for 5 seconds or less (when a message arrives from your bot, Telegram
  * clients clear its typing status).
+ * Channel chats and channel direct messages chats aren't supported.
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
@@ -45,7 +46,7 @@ public class SendChatAction extends BotApiMethodBoolean {
 
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull
-    private String chatId; ///< Unique identifier for the chat to send the message to (Or username for channels)
+    private String chatId; ///< Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername). Channel chats and channel direct messages chats aren't supported.
     /**
      * Type of action to broadcast. Choose one, depending on what the user is about to receive:
      * typing for text messages

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendContact.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendContact.java
@@ -16,6 +16,7 @@ import lombok.extern.jackson.Jacksonized;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
 
@@ -40,6 +41,7 @@ public class SendContact extends BotApiMethodMessage {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String PHONE_NUMBER_FIELD = "phone_number";
     private static final String FIRST_NAME_FIELD = "first_name";
     private static final String LAST_NAME_FIELD = "last_name";
@@ -53,6 +55,7 @@ public class SendContact extends BotApiMethodMessage {
     private static final String BUSINESS_CONNECTION_ID_FIELD = "business_connection_id";
     private static final String MESSAGE_EFFECT_ID_FIELD = "message_effect_id";
     private static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
+    private static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull
@@ -63,6 +66,13 @@ public class SendContact extends BotApiMethodMessage {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     @JsonProperty(PHONE_NUMBER_FIELD)
     @NonNull
     private String phoneNumber; ///< User's phone number
@@ -114,6 +124,14 @@ public class SendContact extends BotApiMethodMessage {
      */
     @JsonProperty(ALLOW_PAID_BROADCAST_FIELD)
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    @JsonProperty(SUGGESTED_POST_PARAMETERS_FIELD)
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDice.java
@@ -16,6 +16,7 @@ import lombok.extern.jackson.Jacksonized;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
 
@@ -45,6 +46,7 @@ public class SendDice extends BotApiMethodMessage {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String EMOJI_FIELD = "emoji";
     private static final String DISABLE_NOTIFICATION_FIELD = "disable_notification";
     private static final String REPLY_TO_MESSAGE_ID_FIELD = "reply_to_message_id";
@@ -55,6 +57,7 @@ public class SendDice extends BotApiMethodMessage {
     private static final String BUSINESS_CONNECTION_ID_FIELD = "business_connection_id";
     private static final String MESSAGE_EFFECT_ID_FIELD = "message_effect_id";
     private static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
+    private static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     /**
      * Unique identifier for the target chat or username of the target channel (in the format @channelusername)
@@ -68,6 +71,13 @@ public class SendDice extends BotApiMethodMessage {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     /**
      * Optional.
      * Emoji on which the dice throw animation is based.
@@ -118,6 +128,14 @@ public class SendDice extends BotApiMethodMessage {
      */
     @JsonProperty(ALLOW_PAID_BROADCAST_FIELD)
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    @JsonProperty(SUGGESTED_POST_PARAMETERS_FIELD)
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDocument.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendDocument.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -57,6 +58,12 @@ public class SendDocument extends SendMediaBotMethod<Message> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     @NonNull
     private InputFile document; ///< File file to send. file_id as String to resend a file that is already on the Telegram servers or Url to upload it
     private String caption; ///< Optional. Document caption (may also be used when resending documents by file_id), 0-200 characters
@@ -106,6 +113,13 @@ public class SendDocument extends SendMediaBotMethod<Message> {
      */
     private Boolean allowPaidBroadcast;
     
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
+
     @Tolerate
     public void setChatId(@NonNull Long chatId) {
         this.chatId = chatId.toString();

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendGame.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendGame.java
@@ -40,6 +40,7 @@ import org.telegram.telegrambots.meta.util.Validations;
  * @author Ruben Bermudez
  * @version 1.0
  * Use this method to send a game. On success, the sent Message is returned.
+ * Games can't be sent to channel direct messages chats and channel chats.
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
@@ -56,6 +57,7 @@ public class SendGame extends BotApiMethodMessage {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String GAME_SHORT_NAME_FIELD = "game_short_name";
     private static final String DISABLE_NOTIFICATION_FIELD = "disable_notification";
     private static final String REPLY_TO_MESSAGE_ID_FIELD = "reply_to_message_id";
@@ -69,13 +71,20 @@ public class SendGame extends BotApiMethodMessage {
 
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull
-    private String chatId; ///< Unique identifier for the chat to send the message to (Or username for channels)
+    private String chatId; ///< Unique identifier for the target chat. Games can't be sent to channel direct messages chats and channel chats.
     /**
      * Unique identifier for the target message thread (topic) of the forum;
      * for forum supergroups only
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     @JsonProperty(GAME_SHORT_NAME_FIELD)
     @NonNull
     private String gameShortName; ///< Short name of the game

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendLocation.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendLocation.java
@@ -16,6 +16,7 @@ import lombok.extern.jackson.Jacksonized;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
 
@@ -39,6 +40,7 @@ public class SendLocation extends BotApiMethodMessage {
 
     private static final String CHATID_FIELD = "chat_id";
     private static final String MESSAGETHREADID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
 
     private static final String LATITUDE_FIELD = "latitude";
     private static final String LONGITUDE_FIELD = "longitude";
@@ -54,6 +56,7 @@ public class SendLocation extends BotApiMethodMessage {
     private static final String REPLY_PARAMETERS_FIELD = "reply_parameters";
     private static final String BUSINESS_CONNECTION_ID_FIELD = "business_connection_id";
     private static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
+    private static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     @JsonProperty(CHATID_FIELD)
     @NonNull
@@ -64,6 +67,13 @@ public class SendLocation extends BotApiMethodMessage {
      */
     @JsonProperty(MESSAGETHREADID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     @JsonProperty(LATITUDE_FIELD)
     @NonNull
     private Double latitude; ///< Latitude of location
@@ -137,6 +147,14 @@ public class SendLocation extends BotApiMethodMessage {
      */
     @JsonProperty(ALLOW_PAID_BROADCAST_FIELD)
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    @JsonProperty(SUGGESTED_POST_PARAMETERS_FIELD)
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMediaBotMethod.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMediaBotMethod.java
@@ -7,6 +7,7 @@ import org.telegram.telegrambots.meta.api.methods.botapimethods.PartialBotApiMet
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 
 import java.io.Serializable;
 
@@ -15,6 +16,7 @@ import java.io.Serializable;
 public abstract class SendMediaBotMethod<T extends Serializable> extends PartialBotApiMethod<T> {
     public static final String CHAT_ID_FIELD = "chat_id";
     public static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    public static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     public static final String REPLY_TO_MESSAGE_ID_FIELD = "reply_to_message_id";
     public static final String DISABLE_NOTIFICATION_FIELD = "disable_notification";
     public static final String PROTECT_CONTENT_FIELD = "protect_content";
@@ -23,10 +25,13 @@ public abstract class SendMediaBotMethod<T extends Serializable> extends Partial
     public static final String REPLY_MARKUP_FIELD = "reply_markup";
     public static final String MESSAGE_EFFECT_ID_FIELD = "message_effect_id";
     public static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
+    public static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     public abstract String getChatId();
 
     public abstract Integer getMessageThreadId();
+
+    public abstract Integer getDirectMessagesTopicId();
 
     public abstract Integer getReplyToMessageId();
 
@@ -47,6 +52,8 @@ public abstract class SendMediaBotMethod<T extends Serializable> extends Partial
     public abstract String getMessageEffectId();
 
     public abstract Boolean getAllowPaidBroadcast();
+
+    public abstract SuggestedPostParameters getSuggestedPostParameters();
 
     public static abstract class SendMediaBotMethodBuilder<T extends Serializable, C extends SendMediaBotMethod<T>, B extends SendMediaBotMethodBuilder<T, C, B>> extends PartialBotApiMethodBuilder<T, C, B> {
 

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMediaGroup.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMediaGroup.java
@@ -52,6 +52,7 @@ public class SendMediaGroup extends PartialBotApiMethod<ArrayList<Message>> {
 
     public static final String CHAT_ID_FIELD = "chat_id";
     public static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    public static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     public static final String MEDIA_FIELD = "media";
     public static final String REPLY_TO_MESSAGE_ID_FIELD = "reply_to_message_id";
     public static final String DISABLE_NOTIFICATION_FIELD = "disable_notification";
@@ -73,6 +74,12 @@ public class SendMediaGroup extends PartialBotApiMethod<ArrayList<Message>> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the messages will be sent;
+     * required if the messages are sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     /**
      * A JSON-serialized array describing photos and videos to be sent, must include 2–10 items
      */

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendMessage.java
@@ -19,6 +19,7 @@ import org.telegram.telegrambots.meta.api.objects.LinkPreviewOptions;
 import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
 
@@ -45,6 +46,7 @@ public class SendMessage extends BotApiMethodMessage {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String TEXT_FIELD = "text";
     private static final String PARSE_MODE_FIELD = "parse_mode";
     private static final String DISABLE_WEB_PAGE_PREVIEW_FIELD = "disable_web_page_preview";
@@ -59,6 +61,7 @@ public class SendMessage extends BotApiMethodMessage {
     private static final String BUSINESS_CONNECTION_ID_FIELD = "business_connection_id";
     private static final String MESSAGE_EFFECT_ID_FIELD = "message_effect_id";
     private static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
+    private static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull
@@ -69,6 +72,13 @@ public class SendMessage extends BotApiMethodMessage {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     @JsonProperty(TEXT_FIELD)
     @NonNull
     private String text; ///< Text of the message to be sent
@@ -125,6 +135,14 @@ public class SendMessage extends BotApiMethodMessage {
      */
     @JsonProperty(ALLOW_PAID_BROADCAST_FIELD)
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    @JsonProperty(SUGGESTED_POST_PARAMETERS_FIELD)
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPaidMedia.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPaidMedia.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.media.paid.InputPaidMedia;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -59,6 +60,8 @@ public class SendPaidMedia extends PartialBotApiMethod<ArrayList<Message>> {
     public static final String BUSINESS_CONNECTION_ID_FIELD = "business_connection_id";
     public static final String PAYLOAD_FIELD = "payload";
     public static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
+    public static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
+    public static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     /**
      * Unique identifier for the target chat or username of the target channel (in the format @channelusername).
@@ -67,6 +70,12 @@ public class SendPaidMedia extends PartialBotApiMethod<ArrayList<Message>> {
      */
     @NonNull
     private String chatId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     /**
      * The number of Telegram Stars that must be paid to buy access to the media
      */
@@ -136,6 +145,13 @@ public class SendPaidMedia extends PartialBotApiMethod<ArrayList<Message>> {
      * The relevant Stars will be withdrawn from the bot's balance
      */
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPhoto.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPhoto.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -61,6 +62,12 @@ public class SendPhoto extends SendMediaBotMethod<Message> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     /**
      * Photo to send. file_id as String to resend a photo that is already on the Telegram servers or URL to upload it
      */
@@ -140,6 +147,13 @@ public class SendPhoto extends SendMediaBotMethod<Message> {
      * The relevant Stars will be withdrawn from the bot's balance
      */
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendSticker.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendSticker.java
@@ -16,6 +16,7 @@ import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -53,6 +54,12 @@ public class SendSticker extends SendMediaBotMethod<Message> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     /**
      * 	Sticker to send.
      * 	Pass a file_id as String to send a file that exists on the Telegram servers (recommended),
@@ -115,6 +122,13 @@ public class SendSticker extends SendMediaBotMethod<Message> {
      * The relevant Stars will be withdrawn from the bot's balance
      */
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVenue.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVenue.java
@@ -16,6 +16,7 @@ import lombok.extern.jackson.Jacksonized;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethodMessage;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
 
@@ -40,6 +41,7 @@ public class SendVenue extends BotApiMethodMessage {
 
     private static final String CHAT_ID_FIELD = "chat_id";
     private static final String MESSAGE_THREAD_ID_FIELD = "message_thread_id";
+    private static final String DIRECT_MESSAGES_TOPIC_ID_FIELD = "direct_messages_topic_id";
     private static final String LATITUDE_FIELD = "latitude";
     private static final String LONGITUDE_FIELD = "longitude";
     private static final String TITLE_FIELD = "title";
@@ -57,6 +59,7 @@ public class SendVenue extends BotApiMethodMessage {
     private static final String BUSINESS_CONNECTION_ID_FIELD = "business_connection_id";
     private static final String MESSAGE_EFFECT_ID_FIELD = "message_effect_id";
     private static final String ALLOW_PAID_BROADCAST_FIELD = "allow_paid_broadcast";
+    private static final String SUGGESTED_POST_PARAMETERS_FIELD = "suggested_post_parameters";
 
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull
@@ -67,6 +70,13 @@ public class SendVenue extends BotApiMethodMessage {
      */
     @JsonProperty(MESSAGE_THREAD_ID_FIELD)
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_ID_FIELD)
+    private Integer directMessagesTopicId;
     @JsonProperty(LATITUDE_FIELD)
     @NonNull
     private Double latitude; ///< Latitude of venue location
@@ -128,6 +138,14 @@ public class SendVenue extends BotApiMethodMessage {
      */
     @JsonProperty(ALLOW_PAID_BROADCAST_FIELD)
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    @JsonProperty(SUGGESTED_POST_PARAMETERS_FIELD)
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideo.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideo.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -65,6 +66,12 @@ public class SendVideo extends SendMediaBotMethod<Message> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     @NonNull
     private InputFile video; ///< Video to send. file_id as String to resend a video that is already on the Telegram servers or URL to upload it
     private Integer duration; ///< Optional. Duration of sent video in seconds
@@ -139,6 +146,13 @@ public class SendVideo extends SendMediaBotMethod<Message> {
      * Start timestamp for the video in the message
      */
     private Integer startTimestamp;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideoNote.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVideoNote.java
@@ -16,6 +16,7 @@ import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -53,6 +54,12 @@ public class SendVideoNote extends SendMediaBotMethod<Message> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     @NonNull
     private InputFile videoNote; ///< Videonote to send. file_id as String to resend a video that is already on the Telegram servers.
     private Integer duration; ///< Optional. Duration of sent video in seconds
@@ -97,6 +104,13 @@ public class SendVideoNote extends SendMediaBotMethod<Message> {
      * The relevant Stars will be withdrawn from the bot's balance
      */
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVoice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendVoice.java
@@ -18,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.MessageEntity;
 import org.telegram.telegrambots.meta.api.objects.ReplyParameters;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostParameters;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
 import org.telegram.telegrambots.meta.util.Validations;
@@ -64,6 +65,12 @@ public class SendVoice extends SendMediaBotMethod<Message> {
      * for forum supergroups only
      */
     private Integer messageThreadId;
+    /**
+     * Optional.
+     * Identifier of the direct messages topic to which the message will be sent;
+     * required if the message is sent to a direct messages chat
+     */
+    private Integer directMessagesTopicId;
     /**
      * Audio file to send. You can either pass a file_id as String to resend an audio that is already on the Telegram servers, 
      * or upload a new audio file using multipart/form-data.
@@ -144,6 +151,13 @@ public class SendVoice extends SendMediaBotMethod<Message> {
      * The relevant Stars will be withdrawn from the bot's balance
      */
     private Boolean allowPaidBroadcast;
+
+    /**
+     * Optional
+     * A JSON-serialized object containing the parameters of the suggested post to send;
+     * for direct messages chats only
+     */
+    private SuggestedPostParameters suggestedPostParameters;
 
     @Tolerate
     public void setChatId(@NonNull Long chatId) {

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/suggestedPost/ApproveSuggestedPost.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/suggestedPost/ApproveSuggestedPost.java
@@ -1,0 +1,95 @@
+package org.telegram.telegrambots.meta.api.methods.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethod;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
+
+/**
+ * @author Ruben Bermudez
+ * @version 7.5
+ *
+ * Use this method to approve a suggested post in a direct messages chat.
+ * The bot must have the 'can_post_messages' administrator right in the corresponding channel chat.
+ * Returns True on success.
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApproveSuggestedPost extends BotApiMethod<Boolean> {
+    public static final String PATH = "approveSuggestedPost";
+
+    private static final String CHAT_ID_FIELD = "chat_id";
+    private static final String MESSAGE_ID_FIELD = "message_id";
+    private static final String SEND_DATE_FIELD = "send_date";
+
+    /**
+     * Unique identifier for the target direct messages chat
+     */
+    @JsonProperty(CHAT_ID_FIELD)
+    @NonNull
+    private Integer chatId;
+
+    /**
+     * Identifier of a suggested post message to approve
+     */
+    @JsonProperty(MESSAGE_ID_FIELD)
+    @NonNull
+    private Integer messageId;
+
+    /**
+     * Optional
+     * Point in time (Unix timestamp) when the post is expected to be published;
+     * omit if the date has already been specified when the suggested post was created.
+     * If specified, then the date must be not more than 2678400 seconds (30 days) in the future
+     */
+    @JsonProperty(SEND_DATE_FIELD)
+    private Integer sendDate;
+
+    @Override
+    public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
+        return deserializeResponse(answer, Boolean.class);
+    }
+
+    @Override
+    public String getMethod() {
+        return PATH;
+    }
+
+    @Override
+    public void validate() throws TelegramApiValidationException {
+        if (chatId == null) {
+            throw new TelegramApiValidationException("ChatId parameter can't be empty", this);
+        }
+        if (messageId == null) {
+            throw new TelegramApiValidationException("MessageId parameter can't be empty", this);
+        }
+        if (sendDate != null) {
+            long currentTime = System.currentTimeMillis() / 1000;
+            if (sendDate > currentTime + 2678400) {
+                throw new TelegramApiValidationException("SendDate can't be more than 30 days in the future", this);
+            }
+        }
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/suggestedPost/DeclineSuggestedPost.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/suggestedPost/DeclineSuggestedPost.java
@@ -1,0 +1,90 @@
+package org.telegram.telegrambots.meta.api.methods.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+import org.telegram.telegrambots.meta.api.methods.botapimethods.BotApiMethod;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiValidationException;
+
+/**
+ * @author Ruben Bermudez
+ * @version 7.5
+ *
+ * Use this method to decline a suggested post in a direct messages chat.
+ * The bot must have the 'can_manage_direct_messages' administrator right in the corresponding channel chat.
+ * Returns True on success.
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DeclineSuggestedPost extends BotApiMethod<Boolean> {
+    public static final String PATH = "declineSuggestedPost";
+
+    private static final String CHAT_ID_FIELD = "chat_id";
+    private static final String MESSAGE_ID_FIELD = "message_id";
+    private static final String COMMENT_FIELD = "comment";
+
+    /**
+     * Unique identifier for the target direct messages chat
+     */
+    @JsonProperty(CHAT_ID_FIELD)
+    @NonNull
+    private Integer chatId;
+
+    /**
+     * Identifier of a suggested post message to decline
+     */
+    @JsonProperty(MESSAGE_ID_FIELD)
+    @NonNull
+    private Integer messageId;
+
+    /**
+     * Optional
+     * Comment for the creator of the suggested post; 0-128 characters
+     */
+    @JsonProperty(COMMENT_FIELD)
+    private String comment;
+
+    @Override
+    public Boolean deserializeResponse(String answer) throws TelegramApiRequestException {
+        return deserializeResponse(answer, Boolean.class);
+    }
+
+    @Override
+    public String getMethod() {
+        return PATH;
+    }
+
+    @Override
+    public void validate() throws TelegramApiValidationException {
+        if (chatId == null) {
+            throw new TelegramApiValidationException("ChatId parameter can't be empty", this);
+        }
+        if (messageId == null) {
+            throw new TelegramApiValidationException("MessageId parameter can't be empty", this);
+        }
+        if (comment != null && comment.length() > 128) {
+            throw new TelegramApiValidationException("Comment cannot be longer than 128 characters", this);
+        }
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/DeleteMessage.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/DeleteMessage.java
@@ -22,12 +22,14 @@ import org.telegram.telegrambots.meta.util.Validations;
  *
  * Use this method to delete a message, including service messages, with the following limitations:
  * - A message can only be deleted if it was sent less than 48 hours ago.
+ * - Service messages about a supergroup, channel, or forum topic creation can't be deleted.
+ * - A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.
  * - Bots can delete outgoing messages in private chats, groups, and supergroups.
  * - Bots can delete incoming messages in private chats.
  * - Bots granted can_post_messages permissions can delete outgoing messages in channels.
  * - If the bot is an administrator of a group, it can delete any message there.
- * - If the bot has can_delete_messages permission in a supergroup or a channel, it can delete any message there.
- * - Service messages about a supergroup, channel, or forum topic creation can't be deleted
+ * - If the bot has can_delete_messages administrator right in a supergroup or a channel, it can delete any message there.
+ * - If the bot has can_manage_direct_messages administrator right in a channel, it can delete any message in the corresponding direct messages chat.
  * Returns True on success.
  */
 @EqualsAndHashCode(callSuper = false)
@@ -46,7 +48,7 @@ public class DeleteMessage extends BotApiMethodBoolean {
     private static final String MESSAGEID_FIELD = "message_id";
 
     /**
-     * Unique identifier for the chat to send the message to (Or username for channels)
+     * Unique identifier for the target chat or username of the target channel (in the format @channelusername)
      */
     @JsonProperty(CHATID_FIELD)
     @NonNull

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/verification/VerifyChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/verification/VerifyChat.java
@@ -41,7 +41,8 @@ public class VerifyChat extends BotApiMethodBoolean {
     private static final String CUSTOM_DESCRIPTION_FIELD = "custom_description";
 
     /**
-     * Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     * Unique identifier for the target chat or username of the target channel (in the format @channelusername).
+     * Channel direct messages chats can't be verified.
      */
     @JsonProperty(CHAT_ID_FIELD)
     @NonNull

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/ReplyParameters.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/ReplyParameters.java
@@ -39,6 +39,7 @@ public class ReplyParameters implements BotApiObject, Validable {
     private static final String QUOTE_FIELD = "quote";
     private static final String QUOTE_ENTITIES_FIELD = "quote_entities";
     private static final String QUOTE_POSITION_FIELD = "quote_position";
+    private static final String CHECKLIST_TASK_ID_FIELD = "checklist_task_id";
 
     /**
      * 	Identifier of the message that will be replied to in the current chat, or in the chat chat_id if it is specified
@@ -49,10 +50,17 @@ public class ReplyParameters implements BotApiObject, Validable {
     /**
      * Optional.
      * If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format @channelusername)
-     * @apiNote Not supported for messages sent on behalf of a business account.
+     * @apiNote Not supported for messages sent on behalf of a business account and messages from channel direct messages chats.
      */
     @JsonProperty(CHAT_ID_FIELD)
     private String chatId;
+
+    /**
+     * Optional.
+     * Identifier of the specific checklist task to be replied to
+     */
+    @JsonProperty(CHECKLIST_TASK_ID_FIELD)
+    private Integer checklistTaskId;
 
     /**
      * Optional.

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/adminrights/ChatAdministratorRights.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/adminrights/ChatAdministratorRights.java
@@ -45,6 +45,7 @@ public class ChatAdministratorRights implements BotApiObject, Validable {
     private static final String CAN_POST_STORIES_FIELD = "can_post_stories";
     private static final String CAN_EDIT_STORIES_FIELD = "can_edit_stories";
     private static final String CAN_DELETE_STORIES_FIELD = "can_delete_stories";
+    private static final String CAN_MANAGE_DIRECT_MESSAGES_FIELD = "can_manage_direct_messages";
 
     /**
      * True, if the user's presence in the chat is hidden
@@ -142,4 +143,11 @@ public class ChatAdministratorRights implements BotApiObject, Validable {
      */
     @JsonProperty(CAN_DELETE_STORIES_FIELD)
     private Boolean canDeleteStories;
+
+    /**
+     * Optional.
+     * True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only
+     */
+    @JsonProperty(CAN_MANAGE_DIRECT_MESSAGES_FIELD)
+    private Boolean canManageDirectMessages;
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chat/ChatFullInfo.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chat/ChatFullInfo.java
@@ -77,6 +77,8 @@ public class ChatFullInfo extends Chat {
     private static final String PERSONAL_CHAT_FIELD  = "personal_chat";
     private static final String CAN_SEND_PAID_MEDIA_FIELD  = "can_send_paid_media";
     private static final String ACCEPTED_GIFT_TYPES_FIELD  = "accepted_gift_types";
+    private static final String IS_DIRECT_MESSAGES_FIELD = "is_direct_messages";
+    private static final String PARENT_CHAT_FIELD = "parent_chat";
 
     /**
      * Optional.
@@ -336,4 +338,18 @@ public class ChatFullInfo extends Chat {
      */
     @JsonProperty(ACCEPTED_GIFT_TYPES_FIELD)
     private AcceptedGiftTypes acceptedGiftTypes;
+
+    /**
+     * Optional.
+     * True, if the chat is the direct messages chat of a channel
+     */
+    @JsonProperty(IS_DIRECT_MESSAGES_FIELD)
+    private Boolean isDirectMessages;
+
+    /**
+     * Optional.
+     * Information about the corresponding channel chat; for direct messages chats only
+     */
+    @JsonProperty(PARENT_CHAT_FIELD)
+    private Chat parentChat;
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberAdministrator.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/chatmember/ChatMemberAdministrator.java
@@ -49,6 +49,7 @@ public class ChatMemberAdministrator implements ChatMember {
     private static final String CAN_POST_STORIES_FIELD = "can_post_stories";
     private static final String CAN_EDIT_STORIES_FIELD = "can_edit_stories";
     private static final String CAN_DELETE_STORIES_FIELD = "can_delete_stories";
+    private static final String CAN_MANAGE_DIRECT_MESSAGES_FIELD = "can_manage_direct_messages";
 
     /**
      * The member's status in the chat, always “administrator”
@@ -155,4 +156,11 @@ public class ChatMemberAdministrator implements ChatMember {
      */
     @JsonProperty(CAN_DELETE_STORIES_FIELD)
     private Boolean canDeleteStories;
+
+    /**
+     * Optional.
+     * True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only
+     */
+    @JsonProperty(CAN_MANAGE_DIRECT_MESSAGES_FIELD)
+    private Boolean canManageDirectMessages;
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/commands/scope/BotCommandScopeChat.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/commands/scope/BotCommandScopeChat.java
@@ -40,7 +40,8 @@ public class BotCommandScopeChat implements BotCommandScope {
     @JsonProperty(TYPE_FIELD)
     private final String type = "chat";
     /**
-     * Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+     * Channel direct messages chats and channel chats aren't supported.
      */
     @JsonProperty(CHATID_FIELD)
     @NonNull

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/commands/scope/BotCommandScopeChatAdministrators.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/commands/scope/BotCommandScopeChatAdministrators.java
@@ -38,7 +38,8 @@ public class BotCommandScopeChatAdministrators implements BotCommandScope {
     @JsonProperty(TYPE_FIELD)
     private final String type = "chat_administrators";
     /**
-     * Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+     * Channel direct messages chats and channel chats aren't supported.
      */
     @JsonProperty(CHATID_FIELD)
     @NonNull

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/commands/scope/BotCommandScopeChatMember.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/commands/scope/BotCommandScopeChatMember.java
@@ -39,7 +39,8 @@ public class BotCommandScopeChatMember implements BotCommandScope {
     @JsonProperty(TYPE_FIELD)
     private final String type = "chat_member";
     /**
-     * Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername).
+     * Channel direct messages chats and channel chats aren't supported.
      */
     @JsonProperty(CHATID_FIELD)
     @NonNull

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/gifts/Gift.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/gifts/Gift.java
@@ -13,6 +13,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.chat.Chat;
 import org.telegram.telegrambots.meta.api.objects.stickers.Sticker;
 
 /**
@@ -38,6 +39,7 @@ public class Gift implements BotApiObject {
     private static final String TOTAL_COUNT_FIELD = "total_count";
     private static final String REMAINING_COUNT_FIELD = "remaining_count";
     private static final String UPGRADE_STAR_COUNT_FIELD = "upgrade_star_count";
+    private static final String PUBLISHER_CHAT_FIELD = "publisher_chat";
 
     /**
      * Unique identifier of the gift
@@ -75,4 +77,11 @@ public class Gift implements BotApiObject {
      */
     @JsonProperty(UPGRADE_STAR_COUNT_FIELD)
     private Integer upgradeStarCount;
+
+    /**
+     * Optional.
+     * Information about the chat that published the gift
+     */
+    @JsonProperty(PUBLISHER_CHAT_FIELD)
+    private Chat publisherChat;
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/gifts/UniqueGift.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/gifts/UniqueGift.java
@@ -13,6 +13,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.chat.Chat;
 
 /**
  * @author Ruben Bermudez
@@ -37,6 +38,7 @@ public class UniqueGift implements BotApiObject {
     private static final String MODEL_FIELD = "model";
     private static final String SYMBOL_FIELD = "symbol";
     private static final String BACKDROP_FIELD = "backdrop";
+    private static final String PUBLISHER_CHAT_FIELD = "publisher_chat";
 
     /**
      * Human-readable name of the regular gift from which this unique gift was upgraded
@@ -71,4 +73,11 @@ public class UniqueGift implements BotApiObject {
      */
     @JsonProperty(BACKDROP_FIELD)
     private UniqueGiftBackdrop backdrop;
+
+    /**
+     * Optional.
+     * Information about the chat that published the gift
+     */
+    @JsonProperty(PUBLISHER_CHAT_FIELD)
+    private Chat publisherChat;
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/gifts/UniqueGiftBackdrop.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/gifts/UniqueGiftBackdrop.java
@@ -31,9 +31,9 @@ import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UniqueGiftBackdrop implements BotApiObject {
-    private static final String NAME_FIELD = "center_color";
-    private static final String COLORS_FIELD = "edge_color";
-    private static final String RARITY_PER_MILLE_FIELD = "symbol_color";
+    private static final String NAME_FIELD = "name";
+    private static final String COLORS_FIELD = "colors";
+    private static final String RARITY_PER_MILLE_FIELD = "rarity_per_mille";
 
     /**
      * Name of the backdrop

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/message/DirectMessagesTopic.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/message/DirectMessagesTopic.java
@@ -1,0 +1,46 @@
+package org.telegram.telegrambots.meta.api.objects.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+/**
+ * This object represents a topic of a direct messages chat.
+ * @author Generated based on Telegram Bot API
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class DirectMessagesTopic implements BotApiObject {
+    private static final String TOPIC_ID_FIELD = "topic_id";
+    private static final String USER_FIELD = "user";
+
+    /**
+     * Unique identifier of the topic
+     */
+    @JsonProperty(TOPIC_ID_FIELD)
+    @NonNull
+    private Integer topicId;
+
+    /**
+     * Optional.
+     * Information about the user that created the topic.
+     * Currently, it is always present
+     */
+    @JsonProperty(USER_FIELD)
+    private User user;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/message/Message.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/message/Message.java
@@ -65,6 +65,12 @@ import org.telegram.telegrambots.meta.api.objects.polls.Poll;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.stickers.Sticker;
 import org.telegram.telegrambots.meta.api.objects.stories.Story;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostApprovalFailed;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostApproved;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostDeclined;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostInfo;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostPaid;
+import org.telegram.telegrambots.meta.api.objects.suggestedpost.SuggestedPostRefunded;
 import org.telegram.telegrambots.meta.api.objects.videochat.VideoChatEnded;
 import org.telegram.telegrambots.meta.api.objects.videochat.VideoChatParticipantsInvited;
 import org.telegram.telegrambots.meta.api.objects.videochat.VideoChatScheduled;
@@ -190,6 +196,15 @@ public class Message implements MaybeInaccessibleMessage {
     private static final String CHECKLIST_FIELD = "checklist";
     private static final String CHECKLIST_TASKS_DONE_FIELD = "checklist_tasks_done";
     private static final String CHECKLIST_TASKS_ADDED_FIELD = "checklist_tasks_added";
+    private static final String REPLY_TO_CHECKLIST_TASK_ID_FIELD = "reply_to_checklist_task_id";
+    private static final String IS_PAID_POST_FIELD = "is_paid_post";
+    private static final String DIRECT_MESSAGES_TOPIC_FIELD = "direct_messages_topic";
+    private static final String SUGGESTED_POST_INFO_FIELD = "suggested_post_info";
+    private static final String SUGGESTED_POST_APPROVED_FIELD = "suggested_post_approved";
+    private static final String SUGGESTED_POST_APPROVAL_FAILED_FIELD = "suggested_post_approval_failed";
+    private static final String SUGGESTED_POST_DECLINED_FIELD = "suggested_post_declined";
+    private static final String SUGGESTED_POST_PAID_FIELD = "suggested_post_paid";
+    private static final String SUGGESTED_POST_REFUNDED_FIELD = "suggested_post_refunded";
 
     /**
      * Unique message identifier inside this chat. In specific instances (e.g., message containing a video sent to a big chat),
@@ -819,6 +834,62 @@ public class Message implements MaybeInaccessibleMessage {
      */
     @JsonProperty(CHECKLIST_TASKS_ADDED_FIELD)
     private ChecklistTasksAdded checklistTasksAdded;
+    /**
+     * Optional.
+     * Identifier of the specific checklist task that is being replied to
+     */
+    @JsonProperty(REPLY_TO_CHECKLIST_TASK_ID_FIELD)
+    private Integer replyToChecklistTaskId;
+    /**
+     * Optional.
+     * True, if the message is a paid post. Note that such posts must not be deleted for 24 hours
+     * to receive the payment and can't be edited.
+     */
+    @JsonProperty(IS_PAID_POST_FIELD)
+    private Boolean isPaidPost;
+    /**
+     * Optional.
+     * Information about the direct messages chat topic that contains the message
+     */
+    @JsonProperty(DIRECT_MESSAGES_TOPIC_FIELD)
+    private DirectMessagesTopic directMessagesTopic;
+    /**
+     * Optional.
+     * Information about suggested post parameters if the message is a suggested post in a channel direct messages chat.
+     * If the message is an approved or declined suggested post, then it can't be edited.
+     */
+    @JsonProperty(SUGGESTED_POST_INFO_FIELD)
+    private SuggestedPostInfo suggestedPostInfo;
+    /**
+     * Optional.
+     * Service message: a suggested post was approved
+     */
+    @JsonProperty(SUGGESTED_POST_APPROVED_FIELD)
+    private SuggestedPostApproved suggestedPostApproved;
+    /**
+     * Optional.
+     * Service message: approval of a suggested post has failed
+     */
+    @JsonProperty(SUGGESTED_POST_APPROVAL_FAILED_FIELD)
+    private SuggestedPostApprovalFailed suggestedPostApprovalFailed;
+    /**
+     * Optional.
+     * Service message: a suggested post was declined
+     */
+    @JsonProperty(SUGGESTED_POST_DECLINED_FIELD)
+    private SuggestedPostDeclined suggestedPostDeclined;
+    /**
+     * Optional.
+     * Service message: payment for a suggested post was received
+     */
+    @JsonProperty(SUGGESTED_POST_PAID_FIELD)
+    private SuggestedPostPaid suggestedPostPaid;
+    /**
+     * Optional.
+     * Service message: payment for a suggested post was refunded
+     */
+    @JsonProperty(SUGGESTED_POST_REFUNDED_FIELD)
+    private SuggestedPostRefunded suggestedPostRefunded;
 
     public List<MessageEntity> getEntities() {
         if (entities != null) {
@@ -1114,5 +1185,50 @@ public class Message implements MaybeInaccessibleMessage {
     @JsonIgnore
     public boolean hasChecklistTasksAdded() {
         return checklistTasksAdded != null;
+    }
+
+    @JsonIgnore
+    public boolean hasReplyToChecklistTaskId() {
+        return replyToChecklistTaskId != null;
+    }
+
+    @JsonIgnore
+    public boolean isPaidPost() {
+        return isPaidPost != null && isPaidPost;
+    }
+
+    @JsonIgnore
+    public boolean hasDirectMessagesTopic() {
+        return directMessagesTopic != null;
+    }
+
+    @JsonIgnore
+    public boolean hasSuggestedPostInfo() {
+        return suggestedPostInfo != null;
+    }
+
+    @JsonIgnore
+    public boolean hasSuggestedPostApproved() {
+        return suggestedPostApproved != null;
+    }
+
+    @JsonIgnore
+    public boolean hasSuggestedPostApprovalFailed() {
+        return suggestedPostApprovalFailed != null;
+    }
+
+    @JsonIgnore
+    public boolean hasSuggestedPostDeclined() {
+        return suggestedPostDeclined != null;
+    }
+
+    @JsonIgnore
+    public boolean hasSuggestedPostPaid() {
+        return suggestedPostPaid != null;
+    }
+
+    @JsonIgnore
+    public boolean hasSuggestedPostRefunded() {
+        return suggestedPostRefunded != null;
     }
 }

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostApprovalFailed.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostApprovalFailed.java
@@ -1,0 +1,53 @@
+package org.telegram.telegrambots.meta.api.objects.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+
+/**
+ * Describes a service message about the failed approval of a suggested post. 
+ * Currently, only caused by insufficient user funds at the time of approval.
+ * @author Generated using AI assistance
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuggestedPostApprovalFailed implements BotApiObject {
+    private static final String SUGGESTED_POST_MESSAGE_FIELD = "suggested_post_message";
+    private static final String PRICE_FIELD = "price";
+
+    /**
+     * Optional.
+     * Message containing the suggested post whose approval has failed. Note that the Message object 
+     * in this field will not contain the reply_to_message field even if it itself is a reply.
+     */
+    @JsonProperty(SUGGESTED_POST_MESSAGE_FIELD)
+    private Message suggestedPostMessage;
+
+    /**
+     * Expected price of the post
+     */
+    @JsonProperty(PRICE_FIELD)
+    @NonNull
+    private SuggestedPostPrice price;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostApproved.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostApproved.java
@@ -1,0 +1,60 @@
+package org.telegram.telegrambots.meta.api.objects.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+
+/**
+ * Describes a service message about the approval of a suggested post.
+ * @author Generated using AI assistance
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuggestedPostApproved implements BotApiObject {
+    private static final String SUGGESTED_POST_MESSAGE_FIELD = "suggested_post_message";
+    private static final String PRICE_FIELD = "price";
+    private static final String SEND_DATE_FIELD = "send_date";
+
+    /**
+     * Optional.
+     * Message containing the suggested post. Note that the Message object in this field will not contain 
+     * the reply_to_message field even if it itself is a reply.
+     */
+    @JsonProperty(SUGGESTED_POST_MESSAGE_FIELD)
+    private Message suggestedPostMessage;
+
+    /**
+     * Optional.
+     * Amount paid for the post
+     */
+    @JsonProperty(PRICE_FIELD)
+    private SuggestedPostPrice price;
+
+    /**
+     * Date when the post will be published
+     */
+    @JsonProperty(SEND_DATE_FIELD)
+    @NonNull
+    private Integer sendDate;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostDeclined.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostDeclined.java
@@ -1,0 +1,49 @@
+package org.telegram.telegrambots.meta.api.objects.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+
+/**
+ * Describes a service message about the rejection of a suggested post.
+ * @author Generated using AI assistance
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuggestedPostDeclined implements BotApiObject {
+    private static final String SUGGESTED_POST_MESSAGE_FIELD = "suggested_post_message";
+    private static final String COMMENT_FIELD = "comment";
+
+    /**
+     * Optional.
+     * Message containing the suggested post. Note that the Message object in this field will not contain 
+     * the reply_to_message field even if it itself is a reply.
+     */
+    @JsonProperty(SUGGESTED_POST_MESSAGE_FIELD)
+    private Message suggestedPostMessage;
+
+    /**
+     * Optional.
+     * Comment with which the post was declined
+     */
+    @JsonProperty(COMMENT_FIELD)
+    private String comment;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostInfo.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostInfo.java
@@ -1,0 +1,59 @@
+package org.telegram.telegrambots.meta.api.objects.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+
+/**
+ * Contains information about a suggested post.
+ * @author Generated using AI assistance
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuggestedPostInfo implements BotApiObject {
+    private static final String STATE_FIELD = "state";
+    private static final String PRICE_FIELD = "price";
+    private static final String SEND_DATE_FIELD = "send_date";
+
+    /**
+     * State of the suggested post. Currently, it can be one of "pending", "approved", "declined".
+     */
+    @JsonProperty(STATE_FIELD)
+    @NonNull
+    private String state;
+
+    /**
+     * Optional. 
+     * Proposed price of the post. If the field is omitted, then the post is unpaid.
+     */
+    @JsonProperty(PRICE_FIELD)
+    private SuggestedPostPrice price;
+
+    /**
+     * Optional.
+     * Proposed send date of the post. If the field is omitted, then the post can be published at any time 
+     * within 30 days at the sole discretion of the user or administrator who approves it.
+     */
+    @JsonProperty(SEND_DATE_FIELD)
+    private Integer sendDate;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostPaid.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostPaid.java
@@ -1,0 +1,70 @@
+package org.telegram.telegrambots.meta.api.objects.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.payments.star.StarAmount;
+
+/**
+ * Describes a service message about a successful payment for a suggested post.
+ * @author Generated using AI assistance
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuggestedPostPaid implements BotApiObject {
+    private static final String SUGGESTED_POST_MESSAGE_FIELD = "suggested_post_message";
+    private static final String CURRENCY_FIELD = "currency";
+    private static final String AMOUNT_FIELD = "amount";
+    private static final String STAR_AMOUNT_FIELD = "star_amount";
+
+    /**
+     * Optional.
+     * Message containing the suggested post. Note that the Message object in this field will not contain 
+     * the reply_to_message field even if it itself is a reply.
+     */
+    @JsonProperty(SUGGESTED_POST_MESSAGE_FIELD)
+    private Message suggestedPostMessage;
+
+    /**
+     * Currency in which the payment was made. Currently, one of "XTR" for Telegram Stars 
+     * or "TON" for toncoins
+     */
+    @JsonProperty(CURRENCY_FIELD)
+    @NonNull
+    private String currency;
+
+    /**
+     * Optional.
+     * The amount of the currency that was received by the channel in nanotoncoins; for payments in toncoins only
+     */
+    @JsonProperty(AMOUNT_FIELD)
+    private Integer amount;
+
+    /**
+     * Optional.
+     * The amount of Telegram Stars that was received by the channel; for payments in Telegram Stars only
+     */
+    @JsonProperty(STAR_AMOUNT_FIELD)
+    private StarAmount starAmount;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostParameters.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostParameters.java
@@ -1,0 +1,49 @@
+package org.telegram.telegrambots.meta.api.objects.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+
+/**
+ * Contains parameters of a post that is being suggested by the bot.
+ * @author Generated using AI assistance
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuggestedPostParameters implements BotApiObject {
+    private static final String PRICE_FIELD = "price";
+    private static final String SEND_DATE_FIELD = "send_date";
+
+    /**
+     * Optional.
+     * Proposed price for the post. If the field is omitted, then the post is unpaid.
+     */
+    @JsonProperty(PRICE_FIELD)
+    private SuggestedPostPrice price;
+
+    /**
+     * Optional.
+     * Proposed send date of the post. If specified, then the date must be between 300 second 
+     * and 2678400 seconds (30 days) in the future. If the field is omitted, then the post 
+     * can be published at any time within 30 days at the sole discretion of the user who approves it.
+     */
+    @JsonProperty(SEND_DATE_FIELD)
+    private Integer sendDate;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostPrice.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostPrice.java
@@ -1,0 +1,50 @@
+package org.telegram.telegrambots.meta.api.objects.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+
+/**
+ * Describes price of a suggested post.
+ * @author Generated using AI assistance
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuggestedPostPrice implements BotApiObject {
+    private static final String CURRENCY_FIELD = "currency";
+    private static final String AMOUNT_FIELD = "amount";
+
+    /**
+     * Currency in which the post will be paid. Currently, must be one of "XTR" for Telegram Stars or "TON" for toncoins
+     */
+    @JsonProperty(CURRENCY_FIELD)
+    @NonNull
+    private String currency;
+
+    /**
+     * The amount of the currency that will be paid for the post in the smallest units of the currency, 
+     * i.e. Telegram Stars or nanotoncoins. Currently, price in Telegram Stars must be between 5 and 100000, 
+     * and price in nanotoncoins must be between 10000000 and 10000000000000.
+     */
+    @JsonProperty(AMOUNT_FIELD)
+    @NonNull
+    private Integer amount;
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostRefunded.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/suggestedpost/SuggestedPostRefunded.java
@@ -1,0 +1,54 @@
+package org.telegram.telegrambots.meta.api.objects.suggestedpost;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+
+/**
+ * Describes a service message about a payment refund for a suggested post.
+ * @author Generated using AI assistance
+ * @version 9.0
+ */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuggestedPostRefunded implements BotApiObject {
+    private static final String SUGGESTED_POST_MESSAGE_FIELD = "suggested_post_message";
+    private static final String REASON_FIELD = "reason";
+
+    /**
+     * Optional.
+     * Message containing the suggested post. Note that the Message object in this field will not contain 
+     * the reply_to_message field even if it itself is a reply.
+     */
+    @JsonProperty(SUGGESTED_POST_MESSAGE_FIELD)
+    private Message suggestedPostMessage;
+
+    /**
+     * Reason for the refund. Currently, one of "post_deleted" if the post was deleted within 24 hours 
+     * of being posted or removed from scheduled messages without being posted, or "payment_refunded" 
+     * if the payer refunded their payment.
+     */
+    @JsonProperty(REASON_FIELD)
+    @NonNull
+    private String reason;
+}

--- a/telegrambots-springboot-longpolling-starter/pom.xml
+++ b/telegrambots-springboot-longpolling-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <artifactId>telegrambots-springboot-longpolling-starter</artifactId>
@@ -60,8 +60,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <telegrambots.version>9.1.0</telegrambots.version>
-        <spring.version>3.2.3</spring.version>
+        <telegrambots.version>9.2.0</telegrambots.version>
+        <spring.version>3.5.5</spring.version>
     </properties>
 
     <dependencyManagement>

--- a/telegrambots-springboot-webhook-starter/pom.xml
+++ b/telegrambots-springboot-webhook-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <artifactId>telegrambots-springboot-webhook-starter</artifactId>
@@ -59,8 +59,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <telegrambots.version>9.1.0</telegrambots.version>
-        <spring.version>3.2.3</spring.version>
+        <telegrambots.version>9.2.0</telegrambots.version>
+        <spring.version>3.5.5</spring.version>
         <jackson.version>2.17.2</jackson.version>
     </properties>
 

--- a/telegrambots-test-reports/pom.xml
+++ b/telegrambots-test-reports/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <artifactId>telegrambots-test-reports</artifactId>

--- a/telegrambots-webhook/pom.xml
+++ b/telegrambots-webhook/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.1.0</version>
+        <version>9.2.0</version>
     </parent>
 
     <artifactId>telegrambots-webhook</artifactId>
@@ -47,7 +47,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <javalin.version>6.1.3</javalin.version>
+        <javalin.version>6.7.0</javalin.version>
         <log4j.version>2.18.0</log4j.version>
     </properties>
 
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.18</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
API 8.3
> ### copyMessage
> - `video_start_timestamp` Integer
> ### forwardMessage
> - `video_start_timestamp` Integer

API 9.2
> ### sendInvoice
> - `direct_messages_topic_id`  Integer
> - `suggested_post_parameters` SuggestedPostParameters