### PR TITLE
Add Missing MarkdownV2 setter to EditMessageText

### DIFF
--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageText.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/updatingmessages/EditMessageText.java
@@ -140,6 +140,14 @@ public class EditMessageText extends BotApiMethodSerializable {
         }
     }
 
+    public void enableMarkdownV2(boolean enable) {
+        if (enable) {
+            this.parseMode = ParseMode.MARKDOWNV2;
+        } else {
+            this.parseMode = null;
+        }
+    }
+
     @Tolerate
     public void setChatId(Long chatId) {
         this.chatId = chatId == null ? null : chatId.toString();


### PR DESCRIPTION
Adding missing method for EditMessageText, based on the respective part for SendMessage