### PR TITLE
feat: create `telegrambots-bom` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pom.xml.versionsBackup
 pom.xml.next
 release.properties
 dependency-reduced-pom.xml
+telegrambots-bom/.flattened-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>telegrambots-springboot-webhook-starter</module>
         <module>telegrambots-extensions</module>
         <module>telegrambots-abilities</module>
+        <module>telegrambots-bom</module>
         <module>telegrambots-test-reports</module>
     </modules>
 

--- a/telegrambots-bom/pom.xml
+++ b/telegrambots-bom/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.telegram</groupId>
+        <artifactId>Bots</artifactId>
+        <version>9.4.0</version>
+    </parent>
+
+    <artifactId>telegrambots-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Telegram Bots BOM</name>
+    <url>https://github.com/rubenlagus/TelegramBots</url>
+    <description>Bill of Materials for TelegramBots artifacts</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-meta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-longpolling</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-webhook</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-client-jetty-adapter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-springboot-longpolling-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-springboot-webhook-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-extensions</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.telegram</groupId>
+                <artifactId>telegrambots-abilities</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.7.3</version>
+                <configuration>
+                    <flattenMode>bom</flattenMode>
+                    <pomElements>
+                        <properties>remove</properties>
+                        <build>remove</build>
+                        <dependencies>remove</dependencies>
+                    </pomElements>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/telegrambots-bom/pom.xml
+++ b/telegrambots-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.telegram</groupId>
         <artifactId>Bots</artifactId>
-        <version>9.4.0</version>
+        <version>9.5.0</version>
     </parent>
 
     <artifactId>telegrambots-bom</artifactId>


### PR DESCRIPTION
This pull request introduces a new Bill of Materials (BOM) module to the project, making it easier to manage and align dependency versions across all TelegramBots artifacts. The main changes are the addition of the new `telegrambots-bom` module and its configuration.

Dependency management improvements:

* Added the `telegrambots-bom` module to the project's main `pom.xml`, so it is now built as part of the overall project.
* Created a new `telegrambots-bom/pom.xml` file that defines a BOM for all major TelegramBots modules, centralizing their version management under `dependencyManagement`.

Build configuration:

* Configured the Maven Flatten plugin in the BOM's `pom.xml` to ensure the BOM is properly flattened for consumers, removing unnecessary elements from the published POM.

Resolves #1576 