### PR TITLE
Docs/readme copyedits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 # Telegram Bot Java Library
 [![Telegram](/TelegramBots.svg)](https://telegram.me/JavaBotsApi)
 
-[![Build Status](https://travis-ci.org/rubenlagus/TelegramBots.svg?branch=master)](https://travis-ci.org/rubenlagus/TelegramBots)
 [![Jitpack](https://jitpack.io/v/rubenlagus/TelegramBots.svg)](https://jitpack.io/#rubenlagus/TelegramBots)
 [![Maven Central](https://img.shields.io/maven-central/v/org.telegram/telegrambots-meta.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.telegram%22)
-[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/rubenlagus/TelegramBots/blob/master/LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/rubenlagus/TelegramBots/blob/master/LICENSE)
 
 A simple-to-use library to create Telegram Bots in Java.
+
+## Requirements
+
+- **Java:** 17 or higher (matches `maven.compiler.release` in the root [`pom.xml`](pom.xml)).
+- **Build:** Apache Maven 3.x, or the included Maven Wrapper ([`mvnw`](mvnw) / [`mvnw.cmd`](mvnw.cmd)).
+
+## Building from source
+
+```bash
+./mvnw clean install
+```
+
+On Windows, use `mvnw.cmd clean install` instead.
 
 ## Contributions
 Feel free to fork this project, work on it and then make a pull request against **DEV** branch. Most of the time I will accept them if they add something valuable to the code.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.telegram/telegrambots-meta.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.telegram%22)
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/rubenlagus/TelegramBots/blob/master/LICENSE)
 
-A simple to use library to create Telegram Bots in Java
+A simple-to-use library to create Telegram Bots in Java.
 
 ## Contributions
-Feel free to fork this project, work on it and then make a pull request against **DEV** branch. Most of the times I will accept them if they add something valuable to the code.
+Feel free to fork this project, work on it and then make a pull request against **DEV** branch. Most of the time I will accept them if they add something valuable to the code.
 
 Please, **DO NOT PUSH ANY TOKEN OR API KEY**, I will never accept a pull request with that content.
 
@@ -30,7 +30,7 @@ https://telegram.me/directionsbot (**Basic messages**)
 
 https://telegram.me/filesbot (**Send files by file_id**)
 
-https://telegram.me/TGlanguagesbot (**Send files uploding them**)
+https://telegram.me/TGlanguagesbot (**Send files uploading them**)
 
 https://telegram.me/RaeBot (**Inline support**)
 
@@ -39,12 +39,12 @@ https://telegram.me/SnowcrashBot (**Webhook support**)
 You can see code for those bots at [TelegramBotsExample](https://github.com/rubenlagus/TelegramBotsExample) project.
 
 ## Telegram Bot API
-This library use [Telegram bot API](https://core.telegram.org/bots), you can find more information following the link.
+This library uses the [Telegram Bot API](https://core.telegram.org/bots). More information is available on the official site.
 
 ## Questions or Suggestions
 Feel free to create issues [here](https://github.com/rubenlagus/TelegramBots/issues) as you need or join the [chat](https://telegram.me/JavaBotsApi)
 
-## Powered by Intellij and DigitalOcean
+## Powered by IntelliJ and DigitalOcean
 <p align="center">
    <a href="https://www.jetbrains.com/?from=TelegramBots"><img src="jetbrains.png" width="75"></a>
    <a href="https://www.digitalocean.com/?refcode=42a4fa8c6d00&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge"><img src="https://web-platforms.sfo2.cdn.digitaloceanspaces.com/WWW/Badge%201.svg" alt="DigitalOcean Referral Badge" /></a>


### PR DESCRIPTION
What: README now states the Java 17 requirement (aligned with root pom.xml), documents building from source with the Maven Wrapper, removes the travis-ci.org build badge (service no longer valid for that URL), and uses HTTPS for the MIT shield.
Why: Reduces failed local builds from wrong JDK and removes a misleading CI badge.