### PR TITLE
Add constructor with custom HttpClient supplier

### DIFF
--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/TelegramBotsLongPollingApplication.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/TelegramBotsLongPollingApplication.java
@@ -39,6 +39,10 @@ public class TelegramBotsLongPollingApplication implements AutoCloseable {
         this(objectMapperSupplier, new TelegramOkHttpClientFactory.DefaultOkHttpClientCreator());
     }
 
+    public TelegramBotsLongPollingApplication(Supplier<OkHttpClient> okHttpClientCreator) {
+        this(ObjectMapper::new, okHttpClientCreator);
+    }
+
     public TelegramBotsLongPollingApplication(Supplier<ObjectMapper> objectMapperSupplier, Supplier<OkHttpClient> okHttpClientCreator) {
         this(objectMapperSupplier, okHttpClientCreator, Executors::newSingleThreadScheduledExecutor);
     }


### PR DESCRIPTION
This PR adds a new constructor that allows overriding `OkHttpClient` while keeping the default `ObjectMapper`

### Problem
Current constructors require both `ObjectMapper` and `HttpClient` suppliers. This causes issues when `ObjectMapper` is relocated to a different namespace

### Solution
```java
public TelegramBotsLongPollingApplication(Supplier<OkHttpClient> okHttpClientCreator) {
    this(ObjectMapper::new, okHttpClientCreator);
}