### PR TITLE
AbilityBot: handle ChatBoostUpdated / ChatBoostRemoved updates (#1463)

### DIFF
--- a/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/objects/Flag.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/objects/Flag.java
@@ -37,6 +37,8 @@ public enum Flag implements Predicate<Update> {
   HAS_EDITED_BUSINESS_MESSAGE(Update::hasEditedBusinessMessage),
   HAS_DELETED_BUSINESS_MESSAGE(Update::hasDeletedBusinessMessage),
   HAS_PAID_MEDIA_PURCHASED(Update::hasPaidMediaPurchased),
+  HAS_CHAT_BOOST(Update::hasChatBoost),
+  HAS_REMOVED_CHAT_BOOST(Update::hasRemovedChatBoost),
 
 
   // Message Flags

--- a/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/util/AbilityUtils.java
+++ b/telegrambots-abilities/src/main/java/org/telegram/telegrambots/abilitybots/api/util/AbilityUtils.java
@@ -6,6 +6,10 @@ import org.telegram.telegrambots.abilitybots.api.objects.MessageContext;
 import org.telegram.telegrambots.abilitybots.api.objects.Flag;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostSource;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostSourceGiftCode;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostSourceGiveaway;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostSourcePremium;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 
 import java.text.MessageFormat;
@@ -99,11 +103,31 @@ public final class AbilityUtils {
       return EMPTY_USER;
     }else if (Flag.HAS_PAID_MEDIA_PURCHASED.test(update)) {
       return update.getPaidMediaPurchased().getUser();
+    } else if (Flag.HAS_CHAT_BOOST.test(update)) {
+      return extractUserFromBoostSource(update.getChatBoost().getBoost().getSource());
+    } else if (Flag.HAS_REMOVED_CHAT_BOOST.test(update)) {
+      return extractUserFromBoostSource(update.getRemovedChatBoost().getSource());
     } else if (Flag.POLL.test(update)) {
       return EMPTY_USER;
     } else {
       throw new IllegalStateException("Could not retrieve originating user from update");
     }
+  }
+
+  /**
+   * Extracts the {@link User} associated with a {@link ChatBoostSource}.
+   * Returns {@link #EMPTY_USER} when the source has no user (anonymous giveaways, or an
+   * unrecognised subtype).
+   */
+  private static User extractUserFromBoostSource(ChatBoostSource source) {
+    if (source instanceof ChatBoostSourcePremium premium) {
+      return defaultIfNull(premium.getUser(), EMPTY_USER);
+    } else if (source instanceof ChatBoostSourceGiftCode giftCode) {
+      return defaultIfNull(giftCode.getUser(), EMPTY_USER);
+    } else if (source instanceof ChatBoostSourceGiveaway giveaway) {
+      return defaultIfNull(giveaway.getUser(), EMPTY_USER);
+    }
+    return EMPTY_USER;
   }
 
   /**
@@ -196,6 +220,10 @@ public final class AbilityUtils {
       return EMPTY_USER.getId();
     } else if (Flag.HAS_PAID_MEDIA_PURCHASED.test(update)) {
       return update.getPaidMediaPurchased().getUser().getId();
+    } else if (Flag.HAS_CHAT_BOOST.test(update)) {
+      return update.getChatBoost().getChat().getId();
+    } else if (Flag.HAS_REMOVED_CHAT_BOOST.test(update)) {
+      return update.getRemovedChatBoost().getChat().getId();
     } else {
       throw new IllegalStateException("Could not retrieve originating chat ID from update");
     }

--- a/telegrambots-abilities/src/test/java/org/telegram/telegrambots/abilitybots/api/util/TestAbilityUtils.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/telegrambots/abilitybots/api/util/TestAbilityUtils.java
@@ -1,0 +1,82 @@
+package org.telegram.telegrambots.abilitybots.api.util;
+
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoost;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostRemoved;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostSourceGiftCode;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostSourceGiveaway;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostSourcePremium;
+import org.telegram.telegrambots.meta.api.objects.boost.ChatBoostUpdated;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for <a href="https://github.com/rubenlagus/TelegramBots/issues/1463">#1463</a>:
+ * {@code AbilityUtils.getUser} threw {@link IllegalStateException} for
+ * {@code ChatBoostUpdated} / {@code ChatBoostRemoved} updates.
+ */
+public class TestAbilityUtils {
+
+    private static final User BOOSTER = new User(42L, "Alice", false);
+
+    @Test
+    void getUser_returnsUserFromPremiumChatBoost() {
+        Update update = new Update();
+        update.setChatBoost(ChatBoostUpdated.builder()
+                .boost(ChatBoost.builder()
+                        .source(ChatBoostSourcePremium.builder().user(BOOSTER).build())
+                        .build())
+                .build());
+
+        assertEquals(BOOSTER, AbilityUtils.getUser(update));
+    }
+
+    @Test
+    void getUser_returnsUserFromGiftCodeChatBoost() {
+        Update update = new Update();
+        update.setChatBoost(ChatBoostUpdated.builder()
+                .boost(ChatBoost.builder()
+                        .source(ChatBoostSourceGiftCode.builder().user(BOOSTER).build())
+                        .build())
+                .build());
+
+        assertEquals(BOOSTER, AbilityUtils.getUser(update));
+    }
+
+    @Test
+    void getUser_returnsUserFromGiveawayChatBoost() {
+        Update update = new Update();
+        update.setChatBoost(ChatBoostUpdated.builder()
+                .boost(ChatBoost.builder()
+                        .source(ChatBoostSourceGiveaway.builder().user(BOOSTER).build())
+                        .build())
+                .build());
+
+        assertEquals(BOOSTER, AbilityUtils.getUser(update));
+    }
+
+    @Test
+    void getUser_returnsEmptyUserFromAnonymousGiveawayChatBoost() {
+        // For anonymous / unclaimed giveaways the user field is null.
+        Update update = new Update();
+        update.setChatBoost(ChatBoostUpdated.builder()
+                .boost(ChatBoost.builder()
+                        .source(ChatBoostSourceGiveaway.builder().isUnclaimed(true).build())
+                        .build())
+                .build());
+
+        assertEquals(AbilityUtils.EMPTY_USER, AbilityUtils.getUser(update));
+    }
+
+    @Test
+    void getUser_returnsUserFromRemovedChatBoost() {
+        Update update = new Update();
+        update.setRemovedChatBoost(ChatBoostRemoved.builder()
+                .source(ChatBoostSourcePremium.builder().user(BOOSTER).build())
+                .build());
+
+        assertEquals(BOOSTER, AbilityUtils.getUser(update));
+    }
+}

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Update.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/Update.java
@@ -285,4 +285,12 @@ public class Update implements BotApiObject {
     public boolean hasPaidMediaPurchased() {
         return paidMediaPurchased != null;
     }
+
+    public boolean hasChatBoost() {
+        return chatBoost != null;
+    }
+
+    public boolean hasRemovedChatBoost() {
+        return removedChatBoost != null;
+    }
 }


### PR DESCRIPTION
Closes #1463.

### The bug

`AbilityUtils.getUser` and `AbilityUtils.getChatId` have no branches for `Update.chatBoost` / `Update.removedChatBoost`, so `BaseAbilityBot.checkBlacklist` throws on every chat-boost update:

```
java.lang.IllegalStateException: Could not retrieve originating user from update
    at AbilityUtils.getUserElseThrow(AbilityUtils.java:104)
    at AbilityUtils.getUser(AbilityUtils.java:61)
    at BaseAbilityBot.checkBlacklist(BaseAbilityBot.java:476)
```

Reproduced in versions 7.x and 8.x per the issue.

### The fix

Three files touched, no behavior changes outside the chat-boost paths:

1. `Update` (`telegrambots-meta`) — added `hasChatBoost()` / `hasRemovedChatBoost()`, mirroring the other `hasXxx` helpers.
2. `Flag` (`telegrambots-abilities`) — added `HAS_CHAT_BOOST` / `HAS_REMOVED_CHAT_BOOST`.
3. `AbilityUtils` (`telegrambots-abilities`) — added branches to both `getUserElseThrow` and `getChatId`:
   - `getUser` resolves the originating user via the `ChatBoostSource` subtype. `ChatBoostSource` is a sealed interface without a common `getUser()`, so I used Java 17 pattern-matching `instanceof` over `ChatBoostSourcePremium` / `ChatBoostSourceGiftCode` / `ChatBoostSourceGiveaway`. Anonymous / unclaimed giveaways (where `user` is `null`) fall back to `EMPTY_USER` instead of throwing.
   - `getChatId` returns the boosted chat's id for both update kinds.

Pattern mirrors PR #1550 which added similar branches for channel posts.

### Tests

New `TestAbilityUtils.java` with 5 cases covering:

- Premium, GiftCode, Giveaway sources all resolve to the originating user
- Anonymous giveaway (null user) → `EMPTY_USER`, no exception
- `ChatBoostRemoved` path

`mvn -pl telegrambots-abilities test` result: **95/95 pass** (90 existing + 5 new). The existing generic `handlesAllUpdates(AbilityUtils::getChatId)` test previously succeeded only because `hasChatBoost` / `hasRemovedChatBoost` didn't exist on `Update`; adding those means it would have started failing if the matching branches weren't added — confirming the fix covers both call paths.