### PR TITLE
Fix shared static executor in LongPollingSingleThreadUpdateConsumer

### DIFF
--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/BotSession.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/BotSession.java
@@ -92,6 +92,11 @@ public class BotSession implements AutoCloseable {
     @Override
     public void close() throws TelegramApiException {
         stop();
+        try {
+            updatesConsumer.close();
+        } catch (Exception e) {
+            log.warn("Failed to close updates consumer", e);
+        }
     }
 
     @NonNull

--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/TelegramBotsLongPollingApplication.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/TelegramBotsLongPollingApplication.java
@@ -91,7 +91,7 @@ public class TelegramBotsLongPollingApplication implements AutoCloseable {
     public void unregisterBot(String botToken) throws TelegramApiException {
         if (botSessions.containsKey(botToken)) {
             BotSession botSession = botSessions.remove(botToken);
-            botSession.stop();
+            botSession.close();
         } else {
             throw new TelegramApiException("Bot is not registered");
         }

--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/interfaces/LongPollingUpdateConsumer.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/interfaces/LongPollingUpdateConsumer.java
@@ -4,6 +4,11 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 
 import java.util.List;
 
-public interface LongPollingUpdateConsumer {
+public interface LongPollingUpdateConsumer extends AutoCloseable {
     void consume(List<Update> updates);
+
+    @Override
+    default void close() throws Exception {
+        // no-op by default
+    }
 }

--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/util/DefaultLongPollingUpdateConsumer.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/util/DefaultLongPollingUpdateConsumer.java
@@ -1,0 +1,39 @@
+package org.telegram.telegrambots.longpolling.util;
+
+import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsumer;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * A single-threaded {@link LongPollingUpdateConsumer} that processes updates one at a time
+ * on a dedicated per-instance background thread.
+ *
+ * <p>Extend this class and implement {@link #consume(Update)} to handle individual updates.
+ * The executor is a daemon thread, so it will not prevent JVM shutdown.
+ * Call {@link #close()} to shut it down explicitly when the bot is deregistered.</p>
+ */
+public abstract class DefaultLongPollingUpdateConsumer implements LongPollingUpdateConsumer {
+    private final ExecutorService updatesProcessorExecutor = Executors.newSingleThreadExecutor();
+
+    @Override
+    public void consume(List<Update> updates) {
+        updates.forEach(update -> {
+            try {
+                updatesProcessorExecutor.execute(() -> consume(update));
+            } catch (RejectedExecutionException ignored) {
+                // Executor has been shut down via close(); incoming updates are discarded
+            }
+        });
+    }
+
+    public abstract void consume(Update update);
+
+    @Override
+    public void close() {
+        updatesProcessorExecutor.shutdown();
+    }
+}

--- a/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/util/LongPollingSingleThreadUpdateConsumer.java
+++ b/telegrambots-longpolling/src/main/java/org/telegram/telegrambots/longpolling/util/LongPollingSingleThreadUpdateConsumer.java
@@ -5,10 +5,28 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+/**
+ * @deprecated Use {@link DefaultLongPollingUpdateConsumer} instead.
+ *             This interface uses a shared static executor across all bot instances,
+ *             which can cause issues when multiple bots are registered in the same application.
+ */
+@Deprecated
 public interface LongPollingSingleThreadUpdateConsumer extends LongPollingUpdateConsumer {
-    Executor updatesProcessorExecutor = Executors.newSingleThreadExecutor();
+    Executor updatesProcessorExecutor = new Executor() {
+        private final ExecutorService delegate = Executors.newSingleThreadExecutor(r -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setDaemon(true);
+            return t;
+        });
+
+        @Override
+        public void execute(Runnable command) {
+            delegate.execute(command);
+        }
+    };
 
     @Override
     default void consume(List<Update> updates) {

--- a/telegrambots-longpolling/src/test/java/org/telegram/telegrambots/longpolling/TestTelegramBotsLongPollingApplicationIntegration.java
+++ b/telegrambots-longpolling/src/test/java/org/telegram/telegrambots/longpolling/TestTelegramBotsLongPollingApplicationIntegration.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsumer;
 import org.telegram.telegrambots.longpolling.util.DefaultGetUpdatesGenerator;
 import org.telegram.telegrambots.longpolling.util.ExponentialBackOff;
 import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -291,6 +293,50 @@ public class TestTelegramBotsLongPollingApplicationIntegration {
         } catch (Exception e) {
             fail(e);
         }
+    }
+
+    @Test
+    public void testConsumerIsClosedOnUnregisterBot() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        LongPollingUpdateConsumer consumer = new LongPollingUpdateConsumer() {
+            @Override
+            public void consume(List<Update> updates) {}
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+
+        Dispatcher dispatcher = getDispatcher(List.of(getFakeUpdates1()));
+        webServer.setDispatcher(dispatcher);
+
+        application.registerBot("TOKEN", () -> telegramUrl, new DefaultGetUpdatesGenerator(), consumer);
+        application.unregisterBot("TOKEN");
+
+        assertTrue(closed.get(), "Consumer close() should be called when bot is unregistered");
+    }
+
+    @Test
+    public void testConsumerIsClosedOnApplicationClose() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        LongPollingUpdateConsumer consumer = new LongPollingUpdateConsumer() {
+            @Override
+            public void consume(List<Update> updates) {}
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+
+        Dispatcher dispatcher = getDispatcher(List.of(getFakeUpdates1()));
+        webServer.setDispatcher(dispatcher);
+
+        application.registerBot("TOKEN", () -> telegramUrl, new DefaultGetUpdatesGenerator(), consumer);
+        application.close();
+
+        assertTrue(closed.get(), "Consumer close() should be called when application is closed");
     }
 
     @NonNull

--- a/telegrambots-longpolling/src/test/java/org/telegram/telegrambots/longpolling/util/TestDefaultLongPollingUpdateConsumer.java
+++ b/telegrambots-longpolling/src/test/java/org/telegram/telegrambots/longpolling/util/TestDefaultLongPollingUpdateConsumer.java
@@ -1,0 +1,166 @@
+package org.telegram.telegrambots.longpolling.util;
+
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestDefaultLongPollingUpdateConsumer {
+
+    @Test
+    public void testUpdatesProcessedOnSeparateThread() throws Exception {
+        Thread callingThread = Thread.currentThread();
+        AtomicReference<Thread> processingThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        DefaultLongPollingUpdateConsumer consumer = new DefaultLongPollingUpdateConsumer() {
+            @Override
+            public void consume(Update update) {
+                processingThread.set(Thread.currentThread());
+                latch.countDown();
+            }
+        };
+
+        Update update = new Update();
+        update.setUpdateId(1);
+        consumer.consume(List.of(update));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNotSame(callingThread, processingThread.get());
+
+        consumer.close();
+    }
+
+    @Test
+    public void testEachInstanceHasOwnExecutor() throws Exception {
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        AtomicReference<Thread> thread1 = new AtomicReference<>();
+        AtomicReference<Thread> thread2 = new AtomicReference<>();
+
+        DefaultLongPollingUpdateConsumer consumer1 = new DefaultLongPollingUpdateConsumer() {
+            @Override
+            public void consume(Update update) {
+                thread1.set(Thread.currentThread());
+                latch1.countDown();
+            }
+        };
+
+        DefaultLongPollingUpdateConsumer consumer2 = new DefaultLongPollingUpdateConsumer() {
+            @Override
+            public void consume(Update update) {
+                thread2.set(Thread.currentThread());
+                latch2.countDown();
+            }
+        };
+
+        Update update = new Update();
+        update.setUpdateId(1);
+        consumer1.consume(List.of(update));
+        consumer2.consume(List.of(update));
+
+        assertTrue(latch1.await(5, TimeUnit.SECONDS));
+        assertTrue(latch2.await(5, TimeUnit.SECONDS));
+        assertNotSame(thread1.get(), thread2.get());
+
+        consumer1.close();
+        consumer2.close();
+    }
+
+    @Test
+    public void testCloseStopsProcessing() throws Exception {
+        CountDownLatch firstLatch = new CountDownLatch(1);
+        AtomicBoolean secondProcessed = new AtomicBoolean(false);
+
+        DefaultLongPollingUpdateConsumer consumer = new DefaultLongPollingUpdateConsumer() {
+            @Override
+            public void consume(Update update) {
+                if (update.getUpdateId() == 1) {
+                    firstLatch.countDown();
+                } else {
+                    secondProcessed.set(true);
+                }
+            }
+        };
+
+        Update update1 = new Update();
+        update1.setUpdateId(1);
+        consumer.consume(List.of(update1));
+        assertTrue(firstLatch.await(5, TimeUnit.SECONDS));
+
+        consumer.close();
+
+        Update update2 = new Update();
+        update2.setUpdateId(2);
+        consumer.consume(List.of(update2));
+
+        Thread.sleep(200);
+        assertFalse(secondProcessed.get(), "No updates should be processed after close()");
+    }
+
+    @Test
+    public void testUpdatesProcessedInOrder() throws Exception {
+        List<Integer> processed = new CopyOnWriteArrayList<>();
+        CountDownLatch latch = new CountDownLatch(3);
+
+        DefaultLongPollingUpdateConsumer consumer = new DefaultLongPollingUpdateConsumer() {
+            @Override
+            public void consume(Update update) {
+                processed.add(update.getUpdateId());
+                latch.countDown();
+            }
+        };
+
+        Update u1 = new Update(); u1.setUpdateId(1);
+        Update u2 = new Update(); u2.setUpdateId(2);
+        Update u3 = new Update(); u3.setUpdateId(3);
+        consumer.consume(List.of(u1, u2, u3));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(List.of(1, 2, 3), processed);
+
+        consumer.close();
+    }
+
+    @Test
+    public void testConsumerOneDoesNotBlockConsumerTwo() throws Exception {
+        CountDownLatch blockingLatch = new CountDownLatch(1);
+        CountDownLatch consumer2Latch = new CountDownLatch(1);
+
+        DefaultLongPollingUpdateConsumer blockingConsumer = new DefaultLongPollingUpdateConsumer() {
+            @Override
+            public void consume(Update update) {
+                try {
+                    blockingLatch.await();
+                } catch (InterruptedException ignored) {
+                }
+            }
+        };
+
+        DefaultLongPollingUpdateConsumer consumer2 = new DefaultLongPollingUpdateConsumer() {
+            @Override
+            public void consume(Update update) {
+                consumer2Latch.countDown();
+            }
+        };
+
+        Update update = new Update();
+        update.setUpdateId(1);
+        blockingConsumer.consume(List.of(update));
+        consumer2.consume(List.of(update));
+
+        assertTrue(consumer2Latch.await(5, TimeUnit.SECONDS),
+                "consumer2 should process independently of the blocked consumer1");
+
+        blockingLatch.countDown();
+        blockingConsumer.close();
+        consumer2.close();
+    }
+}


### PR DESCRIPTION
The executor field in LongPollingSingleThreadUpdateConsumer was implicitly public static final, causing all bot instances to share a single thread. Shutting down one bot's executor would silently break all others.

- Wrap the static executor in an anonymous Executor to prevent external shutdown() calls, and use a daemon thread so it doesn't block JVM exit
- Deprecate LongPollingSingleThreadUpdateConsumer in favour of the new DefaultLongPollingUpdateConsumer abstract class, which gives each instance its own executor and implements AutoCloseable for clean shutdown
- Extend LongPollingUpdateConsumer with AutoCloseable (default no-op) so BotSession can close the consumer without casting
- Wire consumer close() into BotSession.close() and unregisterBot()
- Add 7 new tests covering per-instance isolation, ordering, shutdown behaviour, and lifecycle close propagation

Fixes #1563