### PR TITLE
Fix paid media methods and models to match Telegram Bot API

### DIFF
--- a/telegrambots-client-jetty-adapter/src/main/java/org/telegram/telegrambots/client/AbstractTelegramClient.java
+++ b/telegrambots-client-jetty-adapter/src/main/java/org/telegram/telegrambots/client/AbstractTelegramClient.java
@@ -144,7 +144,7 @@ public abstract class AbstractTelegramClient implements TelegramClient {
     }
 
     @Override
-    public List<Message> execute(SendPaidMedia sendPaidMedia) throws TelegramApiException {
+    public Message execute(SendPaidMedia sendPaidMedia) throws TelegramApiException {
         try {
             return executeAsync(sendPaidMedia).get();
         } catch (Exception e) {

--- a/telegrambots-client-jetty-adapter/src/main/java/org/telegram/telegrambots/client/jetty/JettyTelegramClient.java
+++ b/telegrambots-client-jetty-adapter/src/main/java/org/telegram/telegrambots/client/jetty/JettyTelegramClient.java
@@ -327,7 +327,7 @@ public class JettyTelegramClient extends AbstractTelegramClient {
     }
 
     @Override
-    public CompletableFuture<List<Message>> executeAsync(SendPaidMedia sendPaidMedia) {
+    public CompletableFuture<Message> executeAsync(SendPaidMedia sendPaidMedia) {
         try {
             assertParamNotNull(sendPaidMedia, "sendPaidMedia");
             sendPaidMedia.validate();

--- a/telegrambots-client/src/main/java/org/telegram/telegrambots/client/AbstractTelegramClient.java
+++ b/telegrambots-client/src/main/java/org/telegram/telegrambots/client/AbstractTelegramClient.java
@@ -145,7 +145,7 @@ public abstract class AbstractTelegramClient implements TelegramClient {
     }
 
     @Override
-    public List<Message> execute(SendPaidMedia sendPaidMedia) throws TelegramApiException {
+    public Message execute(SendPaidMedia sendPaidMedia) throws TelegramApiException {
         try {
             return executeAsync(sendPaidMedia).get();
         } catch (Exception e) {

--- a/telegrambots-client/src/main/java/org/telegram/telegrambots/client/okhttp/OkHttpTelegramClient.java
+++ b/telegrambots-client/src/main/java/org/telegram/telegrambots/client/okhttp/OkHttpTelegramClient.java
@@ -317,7 +317,7 @@ public class OkHttpTelegramClient extends AbstractTelegramClient {
     }
 
     @Override
-    public CompletableFuture<List<Message>> executeAsync(SendPaidMedia sendPaidMedia) {
+    public CompletableFuture<Message> executeAsync(SendPaidMedia sendPaidMedia) {
         try {
             assertParamNotNull(sendPaidMedia, "sendPaidMedia");
             sendPaidMedia.validate();

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPaidMedia.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/methods/send/SendPaidMedia.java
@@ -43,7 +43,7 @@ import java.util.List;
 @Jacksonized
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class SendPaidMedia extends PartialBotApiMethod<ArrayList<Message>> {
+public class SendPaidMedia extends PartialBotApiMethod<Message> {
     public static final String PATH = "sendPaidMedia";
 
     public static final String CHAT_ID_FIELD = "chat_id";
@@ -167,8 +167,8 @@ public class SendPaidMedia extends PartialBotApiMethod<ArrayList<Message>> {
     }
 
     @Override
-    public ArrayList<Message> deserializeResponse(String answer) throws TelegramApiRequestException {
-        return deserializeResponseArray(answer, Message.class);
+    public Message deserializeResponse(String answer) throws TelegramApiRequestException {
+        return deserializeResponse(answer, Message.class);
     }
 
     @Override
@@ -181,8 +181,8 @@ public class SendPaidMedia extends PartialBotApiMethod<ArrayList<Message>> {
 
         if (media.isEmpty()) {
             throw new TelegramApiValidationException("Media parameter can't be empty", this);
-        } else if (media.size() < 2 || media.size() > 10) {
-            throw new TelegramApiValidationException("Number of media should be between 2 and 10", this);
+        } else if (media.size() > 10) {
+            throw new TelegramApiValidationException("Number of media must be up to 10", this);
         }
 
         for (InputPaidMedia inputMedia : media) {
@@ -206,7 +206,7 @@ public class SendPaidMedia extends PartialBotApiMethod<ArrayList<Message>> {
         return PATH;
     }
 
-    public static abstract class SendPaidMediaBuilder<C extends SendPaidMedia, B extends SendPaidMediaBuilder<C, B>> extends PartialBotApiMethodBuilder<ArrayList<Message>, C, B> {
+    public static abstract class SendPaidMediaBuilder<C extends SendPaidMedia, B extends SendPaidMediaBuilder<C, B>> extends PartialBotApiMethodBuilder<Message, C, B> {
         @Tolerate
         public SendPaidMediaBuilder<C, B> chatId(@NonNull Long chatId) {
             this.chatId = chatId.toString();

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/media/paid/InputPaidMediaVideo.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/api/objects/media/paid/InputPaidMediaVideo.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
  * @author Ruben Bermudez
  * @version 7.5
  *
- * The paid media to send is a photo.
+ * The paid media to send is a video.
  */
 @SuppressWarnings("unused")
 @EqualsAndHashCode(callSuper = true)
@@ -32,7 +32,7 @@ import java.io.InputStream;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @SuperBuilder
 public class InputPaidMediaVideo extends InputPaidMedia {
-    private static final String TYPE = "photo";
+    private static final String TYPE = "video";
 
     private static final String WIDTH_FIELD = "width";
     private static final String HEIGHT_FIELD = "height";

--- a/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/generics/TelegramClient.java
+++ b/telegrambots-meta/src/main/java/org/telegram/telegrambots/meta/generics/TelegramClient.java
@@ -90,11 +90,11 @@ public interface TelegramClient {
 
     /**
      * Send a paid media
-     * @return If success, list of generated messages
+     * @return If success, generated message
      * @throws TelegramApiException If there is any error sending the media group
      * @see <a href="https://core.telegram.org/bots/api#sendMediaGroup">https://core.telegram.org/bots/api#sendMediaGroup</a>
      */
-    List<Message> execute(SendPaidMedia sendPaidMedia) throws TelegramApiException;
+    Message execute(SendPaidMedia sendPaidMedia) throws TelegramApiException;
 
     /**
      * Set chat profile photo
@@ -224,10 +224,10 @@ public interface TelegramClient {
 
     /**
      * Send a paid media
-     * @return If success, list of generated messages
+     * @return If success, generated message
      * @see <a href="https://core.telegram.org/bots/api#sendMediaGroup">https://core.telegram.org/bots/api#sendMediaGroup</a>
      */
-    CompletableFuture<List<Message>> executeAsync(SendPaidMedia sendPaidMedia);
+    CompletableFuture<Message> executeAsync(SendPaidMedia sendPaidMedia);
 
     /**
      * Set chat profile photo

--- a/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/objects/media/paid/TestInputPaidMedia.java
+++ b/telegrambots-meta/src/test/java/org/telegram/telegrambots/meta/api/objects/media/paid/TestInputPaidMedia.java
@@ -27,7 +27,7 @@ public class TestInputPaidMedia {
     @Test
     public void testInputPaidMediaVideoType() {
         InputPaidMediaVideo inputPaidMediaVideo = new InputPaidMediaVideo("test-media-id");
-        assertEquals("photo", inputPaidMediaVideo.getType());
+        assertEquals("video", inputPaidMediaVideo.getType());
     }
 
     @Test


### PR DESCRIPTION
### Changes

- Fixed `sendPaidMedia` method: it now correctly returns a single `Message` instead of `List<Message>`.
- Updated validation for `SendPaidMedia` — it allows **1 to 10** media items (unlike `SendMediaGroup`, which requires **2 to 10**).
- Fixed `InputPaidMediaVideo` — the `TYPE` constant was incorrectly set to `"photo"`.
- Updated all related classes, methods and tests accordingly.

These changes bring the library in line with the current Telegram Bot API specification for paid media.

**Closes #1422**