### PR TITLE
Complete OkHttp future on response processing failure

### DIFF
--- a/telegrambots-client/src/main/java/org/telegram/telegrambots/client/okhttp/OkHttpFutureCallback.java
+++ b/telegrambots-client/src/main/java/org/telegram/telegrambots/client/okhttp/OkHttpFutureCallback.java
@@ -7,7 +7,6 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.telegram.telegrambots.meta.api.methods.botapimethods.PartialBotApiMethod;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -26,17 +25,18 @@ class OkHttpFutureCallback<T extends Serializable, Method extends PartialBotApiM
     }
 
     @Override
-    public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
+    public void onResponse(@NonNull Call call, @NonNull Response response) {
+        T result;
         try(ResponseBody body = response.body()) {
             if (body == null) {
                 completeExceptionally(new TelegramApiException("Telegram api returned empty response"));
-            } else {
-                try {
-                    complete(method.deserializeResponse(body.string()));
-                } catch (TelegramApiRequestException e) {
-                    completeExceptionally(e);
-                }
+                return;
             }
+            result = method.deserializeResponse(body.string());
+        } catch (Exception e) {
+            completeExceptionally(e);
+            return;
         }
+        complete(result);
     }
 }

--- a/telegrambots-client/src/test/java/org/telegram/telegrambots/client/okhttp/OkHttpFutureCallbackTest.java
+++ b/telegrambots-client/src/test/java/org/telegram/telegrambots/client/okhttp/OkHttpFutureCallbackTest.java
@@ -1,0 +1,87 @@
+package org.telegram.telegrambots.client.okhttp;
+
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.Okio;
+import okio.Source;
+import okio.Timeout;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class OkHttpFutureCallbackTest {
+    @Test
+    void completesExceptionallyWhenResponseBodyReadFails() {
+        SocketException failure = new SocketException("Socket closed");
+        ResponseBody body = new FailingResponseBody(failure);
+        Request request = new Request.Builder().url("https://api.telegram.org").build();
+        Response response = new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(body)
+                .build();
+        OkHttpFutureCallback<Message, SendMessage> callback = new OkHttpFutureCallback<>(
+                new SendMessage("chatId", "text"));
+
+        assertDoesNotThrow(() -> callback.onResponse(mock(Call.class), response));
+
+        assertTrue(callback.isCompletedExceptionally());
+        ExecutionException exception = assertThrows(ExecutionException.class, callback::get);
+        assertSame(failure, exception.getCause());
+    }
+
+    private static class FailingResponseBody extends ResponseBody {
+        private final BufferedSource source;
+
+        private FailingResponseBody(IOException failure) {
+            source = Okio.buffer(new Source() {
+                @Override
+                public long read(Buffer sink, long byteCount) throws IOException {
+                    throw failure;
+                }
+
+                @Override
+                public Timeout timeout() {
+                    return Timeout.NONE;
+                }
+
+                @Override
+                public void close() {
+                }
+            });
+        }
+
+        @Override
+        public MediaType contentType() {
+            return MediaType.get("application/json");
+        }
+
+        @Override
+        public long contentLength() {
+            return -1;
+        }
+
+        @Override
+        public BufferedSource source() {
+            return source;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Complete `OkHttpFutureCallback` exceptionally when reading, closing, or deserializing the response fails.
- Complete a successful result only after `ResponseBody` has been closed.
- Add a regression test for `SocketException` thrown while reading the response.

## Problem

`OkHttpFutureCallback.onResponse()` only handled `TelegramApiRequestException`. An `IOException` from `ResponseBody.string()` escaped from the callback and left the `CompletableFuture` incomplete.

Code waiting on that future could consequently block indefinitely.

## Testing

- Regression test fails against the original `dev` implementation.
- `mvn -pl telegrambots-client -am -Dtest=OkHttpFutureCallbackTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl telegrambots-client -am test`

Fixes #1595